### PR TITLE
Allows more strings to be translated

### DIFF
--- a/main/po/POTFILES.in
+++ b/main/po/POTFILES.in
@@ -13,6 +13,7 @@ src/ui/add_conversation/conference/add_groupchat_dialog.vala
 src/ui/add_conversation/conference/dialog.vala
 src/ui/conversation_summary/message_item.vala
 src/ui/conversation_summary/view.vala
+src/ui/conversation_selector/conversation_row.vala
 src/ui/manage_accounts/add_account_dialog.vala
 src/ui/manage_accounts/dialog.vala
 src/ui/occupant_menu/view.vala

--- a/main/po/dino.pot
+++ b/main/po/dino.pot
@@ -128,6 +128,7 @@ msgid "Join"
 msgstr ""
 
 #: src/ui/conversation_summary/message_item.vala:107
+#: src/ui/conversation_selector/conversation_row.vala:183
 msgid "Just now"
 msgstr ""
 
@@ -137,6 +138,10 @@ msgstr ""
 
 #: src/ui/conversation_summary/view.vala:122
 msgid "has stopped typing"
+msgstr ""
+
+#: src/ui/conversation_selector/conversation_row.vala:181
+msgid "min ago"
 msgstr ""
 
 #: src/ui/manage_accounts/add_account_dialog.vala:21

--- a/main/src/ui/conversation_selector/conversation_row.vala
+++ b/main/src/ui/conversation_selector/conversation_row.vala
@@ -178,9 +178,9 @@ public abstract class ConversationRow : ListBoxRow {
          } else if (timespan > 9 * TimeSpan.MINUTE) {
              return datetime.format("%H:%M");
          } else if (timespan > 1 * TimeSpan.MINUTE) {
-             return (timespan / TimeSpan.MINUTE).to_string() + " min ago";
+             return (timespan / TimeSpan.MINUTE).to_string() + " " + _("min ago");
          } else {
-             return "Just now";
+             return _("Just now");
          }
     }
 }


### PR DESCRIPTION
Thanks to @crscmbbng for noticing, shoul fix dino issue #38 


The issue was a missing _("string") in source file, as seen in other files
It also moves the space outside the translatable string as it seems more coherent not having leading spaces there.