### PR TITLE
Fix a couple of warnings relating to parents of dialogs

### DIFF
--- a/main/data/conversation_selector/view.ui
+++ b/main/data/conversation_selector/view.ui
@@ -4,7 +4,6 @@
         <property name="can_focus">True</property>
         <property name="expand">True</property>
         <property name="orientation">vertical</property>
-        <property name="visible">True</property>
         <child>
             <object class="GtkSearchBar" id="search_bar">
                 <property name="hexpand">True</property>

--- a/main/data/manage_accounts/dialog.ui
+++ b/main/data/manage_accounts/dialog.ui
@@ -3,7 +3,6 @@
     <template class="DinoUiManageAccountsDialog">
         <property name="width-request">700</property>
         <property name="height-request">400</property>
-        <property name="visible">True</property>
         <child type="titlebar">
             <object class="GtkHeaderBar">
                 <property name="title" translatable="yes">Accounts</property>

--- a/main/data/settings_dialog.ui
+++ b/main/data/settings_dialog.ui
@@ -2,7 +2,6 @@
 <interface>
     <template class="DinoUiSettingsDialog">
         <property name="modal">True</property>
-        <property name="visible">True</property>
         <child type="titlebar">
             <object class="GtkHeaderBar">
                 <property name="title" translatable="yes">Preferences</property>

--- a/main/src/ui/conversation_list_titlebar.vala
+++ b/main/src/ui/conversation_list_titlebar.vala
@@ -23,7 +23,7 @@ public class ConversationListTitlebar : Gtk.HeaderBar {
         SimpleAction contacts_action = new SimpleAction("add_chat", null);
         contacts_action.activate.connect(() => {
             AddConversation.Chat.Dialog add_chat_dialog = new AddConversation.Chat.Dialog(stream_interactor);
-            add_chat_dialog.set_transient_for((Window) get_toplevel());
+            add_chat_dialog.set_transient_for(window);
             add_chat_dialog.conversation_opened.connect((conversation) => conversation_opened(conversation));
             add_chat_dialog.show();
         });
@@ -32,7 +32,7 @@ public class ConversationListTitlebar : Gtk.HeaderBar {
         SimpleAction conference_action = new SimpleAction("add_conference", null);
         conference_action.activate.connect(() => {
             AddConversation.Conference.Dialog add_conference_dialog = new AddConversation.Conference.Dialog(stream_interactor);
-            add_conference_dialog.set_transient_for((Window) get_toplevel());
+            add_conference_dialog.set_transient_for(window);
             add_conference_dialog.conversation_opened.connect((conversation) => conversation_opened(conversation));
             add_conference_dialog.show();
         });


### PR DESCRIPTION
Fixes these kind of warnings:
```
(dino:<PID>): Gtk-CRITICAL **: gtk_window_set_transient_for: assertion 'parent == NULL || GTK_IS_WINDOW (parent)' failed
Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.
(dino:<PID>): GLib-GObject-WARNING **: invalid cast from 'GtkPaned' to 'GtkWindow'
```

Also centers these dialogs (settings, add chat, join conversation) on
top of their parent windows.