### PR TITLE
Mention libsoupt dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Build
 * libgee-0.8 (≥ 0.10)
 * libgcrypt (For the OMEMO plugin)
 * libnotify
+* libsoup (For the HTTP files plugin)
 * SQLite3
 
 **Instructions**


### PR DESCRIPTION
Used for HTTP upload since ea174ab632ced082eb0f1c51cea1bc9dc5c7c89e.