### PR TITLE
Focus selected widgets in the accounts dialog

### DIFF
--- a/main/src/ui/util/label_hybrid.vala
+++ b/main/src/ui/util/label_hybrid.vala
@@ -20,6 +20,7 @@ public class LabelHybrid : Stack {
 
     public void show_widget() {
         visible_child_name = "widget";
+        get_child_by_name("widget").grab_focus();
     }
 
     public void show_label() {
@@ -86,6 +87,10 @@ public class EntryLabelHybrid : LabelHybrid {
             }
             return false;
         });
+        entry.focus_out_event.connect(() => {
+            show_label();
+            return false;
+        });
     }
 
     private void update_label() {
@@ -133,6 +138,11 @@ public class ComboBoxTextLabelHybrid : LabelHybrid {
         combobox.changed.connect(() => {
             update_label();
             show_label();
+        });
+        combobox.focus_out_event.connect(() => {
+            update_label();
+            show_label();
+            return false;
         });
         button.clicked.connect(() => {
             combobox.popup();

--- a/plugins/openpgp/src/account_settings_widget.vala
+++ b/plugins/openpgp/src/account_settings_widget.vala
@@ -31,7 +31,7 @@ private class AccountSettingsWidget : Stack, Plugins.AccountSettingsWidget {
     }
 
     public void deactivate() {
-        this.set_visible_child_name("label");
+        set_visible_child_name("label");
     }
 
     public void set_account(Account account) {
@@ -45,7 +45,8 @@ private class AccountSettingsWidget : Stack, Plugins.AccountSettingsWidget {
 
     private void on_button_clicked() {
         activated();
-        this.set_visible_child_name("entry");
+        set_visible_child_name("entry");
+        combobox.grab_focus();
         combobox.popup();
     }
 


### PR DESCRIPTION
Previously, you had to issue two clicks in order to enter something into
the text fields.

This also replaces the `Entry` widgets with their label counterparts
once they lose focus. Since the `ComboBox` handling of focus seems to be
buggy (`focus_out_event` not firing), the OpenPGP key selection lacks
the latter feature.