### PR TITLE
HTTP Upload: Revert to a switch on namespace

### DIFF
--- a/plugins/http-files/src/upload_stream_module.vala
+++ b/plugins/http-files/src/upload_stream_module.vala
@@ -69,12 +69,15 @@ public class UploadStreamModule : XmppStreamModule {
                 return;
             }
             string? url_get = null, url_put = null;
-            // FIXME change back to switch on version in a while (prosody bug)
-            url_get = iq.stanza.get_deep_attribute(flag.ns_ver + ":slot", flag.ns_ver + ":get", flag.ns_ver + ":url");
-            url_put = iq.stanza.get_deep_attribute(flag.ns_ver + ":slot", flag.ns_ver + ":put", flag.ns_ver + ":url");
-            if (url_get == null && url_put == null) {
-                url_get = iq.stanza.get_deep_string_content(flag.ns_ver + ":slot", flag.ns_ver + ":get");
-                url_put = iq.stanza.get_deep_string_content(flag.ns_ver + ":slot", flag.ns_ver + ":put");
+            switch (flag.ns_ver) {
+                case NS_URI_0:
+                    url_get = iq.stanza.get_deep_attribute(flag.ns_ver + ":slot", flag.ns_ver + ":get", flag.ns_ver + ":url");
+                    url_put = iq.stanza.get_deep_attribute(flag.ns_ver + ":slot", flag.ns_ver + ":put", flag.ns_ver + ":url");
+                    break;
+                case NS_URI:
+                    url_get = iq.stanza.get_deep_string_content(flag.ns_ver + ":slot", flag.ns_ver + ":get");
+                    url_put = iq.stanza.get_deep_string_content(flag.ns_ver + ":slot", flag.ns_ver + ":put");
+                    break;
             }
             if (url_get == null || url_put == null) {
                 error_listener(stream, "Error getting upload/download url");


### PR DESCRIPTION
https://hg.prosody.im/prosody-modules/rev/e1edf643fbb1 is now merged, so there is no reason to keep this workaround.

This reverts commit 312372350e24d1ebd8afbb0029fac04f2b64eb83, which was a fix for #123.