### PR TITLE
Use libsecret to store the password

### DIFF
--- a/cmake/FindSecret.cmake
+++ b/cmake/FindSecret.cmake
@@ -1,0 +1,13 @@
+include(PkgConfigWithFallback)
+find_pkg_config_with_fallback(Secret
+    PKG_CONFIG_NAME libsecret-1
+    LIB_NAMES libsecret-1
+    INCLUDE_NAMES libsecret/secret.h
+    INCLUDE_DIR_SUFFIXES libsecret-1 libsecret-1/include
+    DEPENDS GLib Gio
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Secret
+    REQUIRED_VARS Secret_LIBRARY
+    VERSION_VAR Secret_VERSION)

--- a/libdino/CMakeLists.txt
+++ b/libdino/CMakeLists.txt
@@ -4,6 +4,7 @@ find_packages(LIBDINO_PACKAGES REQUIRED
     GLib
     GModule
     GObject
+    Secret
 )
 
 vala_precompile(LIBDINO_VALA_C
@@ -42,6 +43,7 @@ SOURCES
     src/service/muc_manager.vala
     src/service/presence_manager.vala
     src/service/roster_manager.vala
+    src/service/secret_manager.vala
     src/service/stream_interactor.vala
     src/service/util.vala
 

--- a/libdino/src/entity/account.vala
+++ b/libdino/src/entity/account.vala
@@ -9,7 +9,10 @@ public class Account : Object {
     public string domainpart { get { return bare_jid.domainpart; } }
     public string resourcepart { get; set; }
     public Jid bare_jid { get; private set; }
-    public string? password { get; set; }
+    public string? password {
+        owned get { return secret_manager.get_password(); }
+        set { secret_manager.set_password(value); }
+    }
     public string display_name {
         owned get { return alias ?? bare_jid.to_string(); }
     }
@@ -19,13 +22,16 @@ public class Account : Object {
     public DateTime mam_earliest_synced { get; set; default=new DateTime.from_unix_utc(0); }
 
     private Database? db;
+    private SecretManager secret_manager;
 
     public Account(Jid bare_jid, string? resourcepart, string? password, string? alias) {
         this.id = -1;
         this.resourcepart = resourcepart ?? "dino." + Random.next_int().to_string("%x");
         this.bare_jid = bare_jid;
-        this.password = password;
         this.alias = alias;
+
+        this.secret_manager = new SecretManager(bare_jid);
+        this.password = password;
     }
 
     public Account.from_row(Database db, Qlite.Row row) {
@@ -33,11 +39,21 @@ public class Account : Object {
         id = row[db.account.id];
         resourcepart = row[db.account.resourcepart];
         bare_jid = new Jid(row[db.account.bare_jid]);
-        password = row[db.account.password];
         alias = row[db.account.alias];
         enabled = row[db.account.enabled];
         roster_version = row[db.account.roster_version];
         mam_earliest_synced = new DateTime.from_unix_utc(row[db.account.mam_earliest_synced]);
+
+        secret_manager = new SecretManager(bare_jid);
+
+        // If there is a password in the database, send it to libsecret and remove it.
+        string legacy_password = row[db.account.password];
+        if (legacy_password != "") {
+            password = legacy_password;
+            var update = db.account.update().with(db.account.id, "=", id);
+            update.set(db.account.password, "");
+            update.perform();
+        }
 
         notify.connect(on_update);
     }
@@ -47,7 +63,7 @@ public class Account : Object {
         id = (int) db.account.insert()
                 .value(db.account.bare_jid, bare_jid.to_string())
                 .value(db.account.resourcepart, resourcepart)
-                .value(db.account.password, password)
+                .value(db.account.password, "")
                 .value(db.account.alias, alias)
                 .value(db.account.enabled, enabled)
                 .value(db.account.roster_version, roster_version)

--- a/libdino/src/service/secret_manager.vala
+++ b/libdino/src/service/secret_manager.vala
@@ -1,0 +1,43 @@
+using Secret;
+
+using Dino.Entities;
+
+namespace Dino {
+
+public class SecretManager {
+
+    private string user;
+    private string server;
+    private static Secret.Schema schema = new Secret.Schema("org.gnome.keyring.NetworkPassword", Secret.SchemaFlags.NONE,
+                                                            "user", Secret.SchemaAttributeType.STRING,
+                                                            "server", Secret.SchemaAttributeType.STRING,
+                                                            "protocol", Secret.SchemaAttributeType.STRING);
+
+    public SecretManager(Jid jid) {
+        user = jid.localpart;
+        server = jid.domainpart;
+    }
+
+    public string? get_password() {
+        try {
+            return Secret.password_lookup_sync(schema, null,
+                                               "user", user,
+                                               "server", server,
+                                               "protocol", "xmpp");
+        } catch (GLib.Error e) {
+            return null;
+        }
+    }
+
+    public void set_password(string password) {
+        try {
+            Secret.password_store_sync(schema, Secret.COLLECTION_DEFAULT,
+                                       "XMPP account " + user + "@" + server, password, null,
+                                       "user", user,
+                                       "server", server,
+                                       "protocol", "xmpp");
+        } catch (GLib.Error e) { }
+    }
+}
+
+}


### PR DESCRIPTION
Also migrate the old plain-text password to the libsecret store, and replace it with an empty string to avoid keeping it in plain text.

Fixes #102.