### PR TITLE
Remove new from struct initialisation, as it is deprecated

### DIFF
--- a/libdino/src/service/connection_manager.vala
+++ b/libdino/src/service/connection_manager.vala
@@ -58,7 +58,7 @@ public class ConnectionManager {
     }
 
     private class RecMutexWrap {
-        public RecMutex mutex = new RecMutex();
+        public RecMutex mutex = RecMutex();
         public void lock() { mutex.lock(); }
         public void unlock() { mutex.unlock(); }
         public bool trylock() { return mutex.trylock(); }

--- a/libdino/src/service/connection_manager.vala
+++ b/libdino/src/service/connection_manager.vala
@@ -121,7 +121,7 @@ public class ConnectionManager {
     }
 
     public Core.XmppStream? connect(Account account) {
-        if (!connection_mutexes.contains(account)) connection_mutexes[account] = new RecMutexWrap();
+        if (!connection_mutexes.has_key(account)) connection_mutexes[account] = new RecMutexWrap();
         if (!connection_todo.contains(account)) connection_todo.add(account);
         if (!connections.has_key(account)) {
             return connect_(account);

--- a/main/src/ui/conversation_summary/conversation_view.vala
+++ b/main/src/ui/conversation_summary/conversation_view.vala
@@ -27,7 +27,7 @@ public class ConversationView : Box, Plugins.ConversationItemCollection {
     private double? was_upper;
     private double? was_page_size;
 
-    private Mutex reloading_mutex = new Mutex();
+    private Mutex reloading_mutex = Mutex();
     private bool animate = false;
 
     public ConversationView(StreamInteractor stream_interactor) {

--- a/xmpp-vala/src/module/xep/0082_date_time_profiles.vala
+++ b/xmpp-vala/src/module/xep/0082_date_time_profiles.vala
@@ -1,7 +1,7 @@
 namespace Xmpp.Xep.DateTimeProfiles {
 
 public DateTime? parse_string(string time_string) {
-    TimeVal time_val = new TimeVal();
+    TimeVal time_val = TimeVal();
     if (time_val.from_iso8601(time_string)) {
         return new DateTime.from_unix_utc(time_val.tv_sec);
     }


### PR DESCRIPTION
Fixes three warnings, part one of many for #176.