### PR TITLE
Add an override to disable TLS verification, fixes #57

### DIFF
--- a/libdino/src/entity/account.vala
+++ b/libdino/src/entity/account.vala
@@ -13,6 +13,12 @@ public class Account : Object {
     public string display_name {
         owned get { return alias ?? bare_jid.to_string(); }
     }
+    public bool is_insecure {
+        get {
+            if (alias == null) return false;
+            return alias == "MAN IN THE MIDDLE ME";
+        }
+    }
     public string? alias { get; set; }
     public bool enabled { get; set; default = false; }
     public string? roster_version { get; set; }

--- a/libdino/src/service/connection_manager.vala
+++ b/libdino/src/service/connection_manager.vala
@@ -164,6 +164,7 @@ public class ConnectionManager {
         if (resource == null) resource = account.resourcepart;
 
         Core.XmppStream stream = new Core.XmppStream();
+        stream.is_insecure = account.is_insecure;
         foreach (Core.XmppStreamModule module in module_manager.get_modules(account, resource)) {
             stream.add_module(module);
         }

--- a/xmpp-vala/src/core/xmpp_stream.vala
+++ b/xmpp-vala/src/core/xmpp_stream.vala
@@ -16,6 +16,7 @@ public class XmppStream {
     public string remote_name;
     public XmppLog log = new XmppLog();
     public StanzaNode? features { get; private set; default = new StanzaNode.build("features", NS_URI); }
+    public bool is_insecure = false;
 
     private IOStream? stream;
     private StanzaReader? reader;

--- a/xmpp-vala/src/module/tls.vala
+++ b/xmpp-vala/src/module/tls.vala
@@ -27,6 +27,9 @@ namespace Xmpp.Tls {
                     var io_stream = stream.get_stream();
                     if (io_stream == null) return;
                     var conn = TlsClientConnection.new(io_stream, identity);
+                    if (stream.is_insecure) {
+                        conn.validation_flags = 0;
+                    }
                     // TODO: Add certificate error handling, that is, allow the
                     // program to handle certificate errors. The certificate
                     // *is checked* by TlsClientConnection, and connection is

--- a/xmpp-vala/src/module/xep/0368_srv_records_tls.vala
+++ b/xmpp-vala/src/module/xep/0368_srv_records_tls.vala
@@ -39,9 +39,12 @@ public class TlsConnectionProvider : ConnectionProvider {
         SocketClient client = new SocketClient();
         try {
             IOStream? io_stream = client.connect_to_host(srv_target.get_hostname(), srv_target.get_port());
-            io_stream = TlsClientConnection.new(io_stream, new NetworkAddress(srv_target.get_hostname(), srv_target.get_port()));
+            TlsClientConnection? io_stream_tls = TlsClientConnection.new(io_stream, new NetworkAddress(srv_target.get_hostname(), srv_target.get_port()));
+            if (stream.is_insecure) {
+                io_stream_tls.validation_flags = 0;
+            }
             stream.add_flag(new Tls.Flag() { finished=true });
-            return io_stream;
+            return (IOStream?) io_stream_tls;
         } catch (Error e) {
             return null;
         }


### PR DESCRIPTION
Sometimes you might want to connect to an XMPP server with a bad TLS setup.
This commit allows the user to disable all TLS validation options in an
insecure mode.

To enable this, the user must change their account's local alias to
"MAN IN THE MIDDLE ME" - to reflect the dodgy nature of the setting.

---

I'm not sure about the UI, but I suppose it is a starting point for this discussion.  This is not a good setting - it really shouldn't be used a lot; so I'm not sure if it deserves a better UX.