### PR TITLE
Use a more portable interpreter for configure

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 OPTS=`getopt -o "h" --long \
 help,fetch-only,no-debug,disable-fast-vapi,with-tests,\


### PR DESCRIPTION
`/bin/bash` is a Linux-ism and isn't very portable (eg. installing bash on FreeBSD sticks it at `/usr/local/bin/bash`), however, the configure script runs on `/bin/sh` fine.