### PR TITLE
Add an appdata file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set_path(SHARE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/share" "Installation dire
 
 set_path(BIN_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/bin" "Installation directory for user executables")
 set_path(DATA_INSTALL_DIR "${SHARE_INSTALL_PREFIX}/dino" "Installation directory for dino-specific data")
+set_path(APPDATA_FILE_INSTALL_DIR "${SHARE_INSTALL_PREFIX}/metainfo" "Installation directory for .appdata.xml files")
 set_path(DESKTOP_FILE_INSTALL_DIR "${SHARE_INSTALL_PREFIX}/applications" "Installation directory for .desktop files")
 set_path(SERVICE_FILE_INSTALL_DIR "${SHARE_INSTALL_PREFIX}/dbus-1/services" "Installation directory for .service files")
 set_path(ICON_INSTALL_DIR "${SHARE_INSTALL_PREFIX}/icons" "Installation directory for icons")

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -151,6 +151,7 @@ if(WIN32)
 endif(WIN32)
 
 install(TARGETS dino ${TARGET_INSTALL})
+install(FILES data/im.dino.Dino.appdata.xml DESTINATION ${APPDATA_FILE_INSTALL_DIR})
 install(FILES data/im.dino.Dino.desktop DESTINATION ${DESKTOP_FILE_INSTALL_DIR})
 install(FILES data/im.dino.Dino.service DESTINATION ${SERVICE_FILE_INSTALL_DIR})
 install(FILES data/icons/im.dino.Dino.svg DESTINATION ${ICON_INSTALL_DIR}/hicolor/scalable/apps)

--- a/main/data/im.dino.Dino.appdata.xml
+++ b/main/data/im.dino.Dino.appdata.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>im.dino.Dino</id>
+  <launchable type="desktop-id">im.dino.Dino.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0+</project_license>
+  <name>Dino</name>
+  <summary>Modern XMPP Client</summary>
+  <description>
+    <p>
+      Dino is a modern open-source chat client for the desktop. It focuses on providing a clean and reliable
+      Jabber/XMPP experience while having your privacy in mind.
+    </p>
+    <p>
+      It supports end-to-end encryption with OMEMO and OpenPGP and allows configuring privacy-related features
+      such as read marker and typing notifications.
+    </p>
+    <p>
+      Dino fetches history from the server and synchronizes messages with other devices.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Main window with conversations</caption>
+      <image height="900" width="1600">https://dino.im/img/appdata/main.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Start a chat</caption>
+      <image height="900" width="1600">https://dino.im/img/appdata/start_chat.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Contact details</caption>
+      <image height="900" width="1600">https://dino.im/img/appdata/contact_details.png</image>
+    </screenshot>
+  </screenshots>
+  <translation type="gettext">dino</translation>
+  <developer_name>Dino Development Team</developer_name>
+  <url type="homepage">https://dino.im</url>
+  <url type="bugtracker">https://github.com/dino/dino/issues</url>
+  <url type="donation">https://liberapay.com/Dino</url>
+  <url type="translate">https://hosted.weblate.org/projects/dino/</url>
+  <!-- TODO: Point this to a webpage with documentation when there is one
+  <url type="help">http://dino.im/help/</url>
+  -->
+  <update_contact>appstream@dino.im</update_contact>
+
+  <!-- TODO: Write this when Dino is released
+  <releases>
+    <release date="XXXX-XX-XX" version="X.X">
+      <description>
+        <p>
+          This is our first release. It comes with a clean UI, notifications,
+          end-to-end encryption support (OMEMO and GnuPG), multi-user chats,
+          and more!
+        </p>
+      </description>
+    </release>
+  </releases>
+  -->
+</component>


### PR DESCRIPTION
This allows "app center" applications like GNOME Software and Plasma Discover to show Dino in all its glory, so users can install it simply.