### PR TITLE
Implement SIMS sending in HTTP Upload plugin

### DIFF
--- a/xmpp-vala/CMakeLists.txt
+++ b/xmpp-vala/CMakeLists.txt
@@ -68,6 +68,7 @@ SOURCES
     "src/module/xep/0313_message_archive_management.vala"
     "src/module/xep/0333_chat_markers.vala"
     "src/module/xep/0368_srv_records_tls.vala"
+    "src/module/xep/0385_stateless_inline_media_sharing.vala"
     "src/module/xep/pixbuf_storage.vala"
 PACKAGES
     ${ENGINE_PACKAGES}

--- a/xmpp-vala/CMakeLists.txt
+++ b/xmpp-vala/CMakeLists.txt
@@ -63,6 +63,7 @@ SOURCES
     "src/module/xep/0199_ping.vala"
     "src/module/xep/0184_message_delivery_receipts.vala"
     "src/module/xep/0203_delayed_delivery.vala"
+    "src/module/xep/0234_jingle_file_transfer.vala"
     "src/module/xep/0280_message_carbons.vala"
     "src/module/xep/0313_message_archive_management.vala"
     "src/module/xep/0333_chat_markers.vala"

--- a/xmpp-vala/src/module/xep/0234_jingle_file_transfer.vala
+++ b/xmpp-vala/src/module/xep/0234_jingle_file_transfer.vala
@@ -1,0 +1,26 @@
+using Xmpp.Core;
+
+namespace Xmpp.Xep.JingleFileTransfer {
+    private const string NS_URI = "urn:xmpp:jingle:apps:file-transfer:5";
+
+    public StanzaNode generate_file_element(string? name, string? media_type, int? size) {
+        //string sha1 = Checksum.compute_for_data(ChecksumType.SHA1, image);
+        StanzaNode file_node = new StanzaNode.build("file", NS_URI).add_self_xmlns();
+        if (name != null) {
+            StanzaNode name_node = new StanzaNode.build("name", NS_URI);
+            name_node.put_node(new StanzaNode.text(name));
+            file_node.put_node(name_node);
+        }
+        if (media_type != null) {
+            StanzaNode media_type_node = new StanzaNode.build("media-type", NS_URI);
+            media_type_node.put_node(new StanzaNode.text(media_type));
+            file_node.put_node(media_type_node);
+        }
+        if (size != null) {
+            StanzaNode size_node = new StanzaNode.build("size", NS_URI);
+            size_node.put_node(new StanzaNode.text(size.to_string()));
+            file_node.put_node(size_node);
+        }
+        return file_node;
+    }
+}

--- a/xmpp-vala/src/module/xep/0385_stateless_inline_media_sharing.vala
+++ b/xmpp-vala/src/module/xep/0385_stateless_inline_media_sharing.vala
@@ -1,0 +1,36 @@
+using Gee;
+using Xmpp.Core;
+
+namespace Xmpp.Xep.StatelessInlineMediaSharing {
+
+public const string NS_URI = "urn:xmpp:sims:1";
+public const string NS_URI_REFERENCE = "urn:xmpp:reference:0";
+
+public static void add_sims_to_message(Message.Stanza message, int begin, int end, Gee.List<string> uris, string? name, string? media_type, int? size) {
+    // TODO: Put that in a references namespace.
+    StanzaNode reference = new StanzaNode.build("reference", NS_URI_REFERENCE).add_self_xmlns();
+    reference.set_attribute("begin", begin.to_string());
+    reference.set_attribute("end", end.to_string());
+    reference.set_attribute("type", "data");
+
+    StanzaNode media_sharing = new StanzaNode.build("media-sharing", NS_URI).add_self_xmlns();
+
+    StanzaNode jingle_ft = Xep.JingleFileTransfer.generate_file_element(name, media_type, size);
+    media_sharing.put_node(jingle_ft);
+
+    StanzaNode sources = new StanzaNode.build("sources", NS_URI);
+    foreach (string uri in uris) {
+        StanzaNode source = new StanzaNode.build("reference", NS_URI);
+        source.set_attribute("type", "data");
+        source.set_attribute("uri", uri);
+        sources.put_node(source);
+    }
+    media_sharing.put_node(sources);
+
+    reference.put_node(media_sharing);
+    message.stanza.put_node(reference);
+}
+
+// TODO: add receiving.
+
+}


### PR DESCRIPTION
This allows receiving clients to know about the file they are receiving before having to query any external entity through HTTP.  There is no additional leak of metadata compared to what the HTTP server would answer.  There is no code to handle receiving files that way, this may be implemented in another PR.  The [Movim](https://movim.eu/) client requires this information in order to show images inline.

This also implements a very small subset of [XEP-0234: Jingle File Transfer](https://xmpp.org/extensions/xep-0234.html), namely the <file/> element, containing <name/>, <media-type/> and <size/>.

I didn’t create a specific Xep namespace for XEP-0372 because it’s quite terribly specified for now, I left a TODO in order to split it in the future.

There is also an issue in the length calculation for the reference, it should be in Unicode codepoints instead of in bytes, I left an XXX comment there.