### PR TITLE
Pass avatars as filenames

### DIFF
--- a/libdino/src/service/avatar_manager.vala
+++ b/libdino/src/service/avatar_manager.vala
@@ -81,6 +81,26 @@ public class AvatarManager : StreamInteractionModule, Object {
         return null;
     }
 
+    public string? get_avatar_path(Account account, Jid jid) {
+        Jid jid_ = jid;
+        if (!stream_interactor.get_module(MucManager.IDENTITY).is_groupchat_occupant(jid, account)) {
+            jid_ = jid.bare_jid;
+        }
+        lock(user_avatars) {
+            string? user_avatars_id = user_avatars[jid_];
+            if (user_avatars_id != null) {
+                return avatar_storage.get_image_path(user_avatars_id);
+            }
+        }
+        lock(vcard_avatars) {
+            string? vcard_avatars_id = vcard_avatars[jid_];
+            if (vcard_avatars_id != null) {
+                return avatar_storage.get_image_path(vcard_avatars_id);
+            }
+        }
+        return null;
+    }
+
     public void publish(Account account, string file) {
         try {
             Pixbuf pixbuf = new Pixbuf.from_file(file);

--- a/libdino/src/service/avatar_storage.vala
+++ b/libdino/src/service/avatar_storage.vala
@@ -35,5 +35,13 @@ public class AvatarStorage : Xep.PixbufStorage, Object {
             return null;
         }
     }
+
+    public string? get_image_path(string id) {
+        if (has_image(id)) {
+            return Path.build_filename(folder, id);
+        } else {
+            return null;
+        }
+    }
 }
 }

--- a/main/src/ui/notifications.vala
+++ b/main/src/ui/notifications.vala
@@ -61,9 +61,8 @@ public class Notifications : Object {
             }
             notifications[conversation].set_title(display_name);
             notifications[conversation].set_body(text);
-            try {
-                notifications[conversation].set_icon(get_pixbuf_icon((new AvatarGenerator(40, 40)).draw_conversation(stream_interactor, conversation)));
-            } catch (Error e) { }
+            string filestring = stream_interactor.get_module(AvatarManager.IDENTITY).get_avatar_path(conversation.account, message.counterpart);
+            notifications[conversation].set_icon(new FileIcon(File.new_for_path(filestring)));
             window.get_application().send_notification(conversation.id.to_string(), notifications[conversation]);
             active_conversation_ids.add(conversation.id.to_string());
             window.urgency_hint = true;
@@ -76,9 +75,8 @@ public class Notifications : Object {
 
         Notification notification = new Notification(_("Subscription request"));
         notification.set_body(jid.bare_jid.to_string());
-        try {
-            notification.set_icon(get_pixbuf_icon((new AvatarGenerator(40, 40)).draw_jid(stream_interactor, jid, account)));
-        } catch (Error e) { }
+        string filestring = stream_interactor.get_module(AvatarManager.IDENTITY).get_avatar_path(account, jid);
+        notification.set_icon(new FileIcon(File.new_for_path(filestring)));
         notification.set_default_action_and_target_value("app.open-conversation", new Variant.int32(conversation.id));
         notification.add_button_with_target_value(_("Accept"), "app.accept-subscription", conversation.id);
         notification.add_button_with_target_value(_("Deny"), "app.deny-subscription", conversation.id);
@@ -96,11 +94,6 @@ public class Notifications : Object {
         return true;
     }
 
-    private Icon get_pixbuf_icon(Gdk.Pixbuf avatar) throws Error {
-        uint8[] buffer;
-        avatar.save_to_buffer(out buffer, "png");
-        return new BytesIcon(new Bytes(buffer));
-    }
 }
 
 }


### PR DESCRIPTION
The GNotification interface does not support Icons of the type
GBytesIcon on libnotify backends. So the avatars passed with a
notification won't get displayed.

Skipping the PixBuf loading steps, will save calculation time
and enable the notification daemon to display the avatars again.

Fixes #239 