### PR TITLE
Fix typos in comments and variable names

### DIFF
--- a/libdino/src/entity/file_transfer.vala
+++ b/libdino/src/entity/file_transfer.vala
@@ -44,7 +44,7 @@ public class FileTransfer : Object {
         this.db = db;
 
         id = row[db.file_transfer.id];
-        account = db.get_account_by_id(row[db.file_transfer.account_id]); // TODO dont have to generate acc new
+        account = db.get_account_by_id(row[db.file_transfer.account_id]); // TODO don’t have to generate acc new
 
         string counterpart_jid = db.get_jid_by_id(row[db.file_transfer.counterpart_id]);
         string counterpart_resource = row[db.file_transfer.counterpart_resource];

--- a/libdino/src/entity/message.vala
+++ b/libdino/src/entity/message.vala
@@ -63,7 +63,7 @@ public class Message : Object {
         this.db = db;
 
         id = row[db.message.id];
-        account = db.get_account_by_id(row[db.message.account_id]); // TODO dont have to generate acc new
+        account = db.get_account_by_id(row[db.message.account_id]); // TODO don’t have to generate acc new
         stanza_id = row[db.message.stanza_id];
         type_ = (Message.Type) row[db.message.type_];
 

--- a/libdino/src/service/entity_capabilities_storage.vala
+++ b/libdino/src/service/entity_capabilities_storage.vala
@@ -16,8 +16,8 @@ public class EntityCapabilitiesStorage : Xep.EntityCapabilities.Storage, Object 
         db.add_entity_features(entity, features);
     }
 
-    public Gee.List<string> get_features(string entitiy) {
-        return db.get_entity_features(entitiy);
+    public Gee.List<string> get_features(string entity) {
+        return db.get_entity_features(entity);
     }
 }
 }

--- a/main/src/ui/conversation_summary/default_file_display.vala
+++ b/main/src/ui/conversation_summary/default_file_display.vala
@@ -67,7 +67,7 @@ public class DefaultFileDisplay : Plugins.MetaConversationItem {
                 try{
                     AppInfo.launch_default_for_uri("file://" + file_transfer.get_uri(), null);
                 } catch (Error err) {
-                    print("Tryed to open " + file_transfer.get_uri());
+                    print("Tried to open " + file_transfer.get_uri());
                 }
             }
             return false;

--- a/main/src/ui/conversation_summary/image_display.vala
+++ b/main/src/ui/conversation_summary/image_display.vala
@@ -83,7 +83,7 @@ public class ImageDisplay : Plugins.MetaConversationItem {
             try{
                 AppInfo.launch_default_for_uri(file_transfer.info, null);
             } catch (Error err) {
-                print("Tryed to open " + file_transfer.info);
+                print("Tried to open " + file_transfer.info);
             }
         });
 

--- a/main/src/ui/conversation_summary/message_textview.vala
+++ b/main/src/ui/conversation_summary/message_textview.vala
@@ -117,7 +117,7 @@ public class MessageTextView : TextView {
             try{
                 AppInfo.launch_default_for_uri(url, null);
             } catch (Error err) {
-                print("Tryed to open " + url);
+                print("Tried to open " + url);
             }
         }
         return false;

--- a/plugins/signal-protocol/tests/common.vala
+++ b/plugins/signal-protocol/tests/common.vala
@@ -52,7 +52,7 @@ void fail_if_not_error_code(ErrorFunc func, int expectedCode, string? reason = n
         func();
         fail_if_reached(@"$(reason + ": " ?? "")no error thrown");
     } catch (Error e) {
-        fail_if_not_eq_int(e.code, expectedCode, @"$(reason + ": " ?? "")catched unexpected error");
+        fail_if_not_eq_int(e.code, expectedCode, @"$(reason + ": " ?? "")caught unexpected error");
     }
 }
 

--- a/xmpp-vala/src/core/stanza_node.vala
+++ b/xmpp-vala/src/core/stanza_node.vala
@@ -282,7 +282,7 @@ public class StanzaNode : StanzaEntry {
     }
 
     /**
-    *    Set only occurence
+    *    Set only occurrence
     **/
     public void set_attribute(string name, string val, string? ns_uri = null) {
         if (ns_uri == null) ns_uri = this.ns_uri;

--- a/xmpp-vala/src/module/xep/0030_service_discovery/flag.vala
+++ b/xmpp-vala/src/module/xep/0030_service_discovery/flag.vala
@@ -13,7 +13,7 @@ public class Flag : XmppStreamFlag {
     public Gee.List<string> features = new ArrayList<string>();
 
     public Gee.List<Identity>? get_entity_categories(string jid) {
-        return entity_identities.has_key(jid) ? entity_identities[jid] : null; // TODO isnt this default for hashmap
+        return entity_identities.has_key(jid) ? entity_identities[jid] : null; // TODO isn’t this default for hashmap
     }
 
     public bool? has_entity_identity(string jid, string category, string type) {

--- a/xmpp-vala/src/module/xep/0115_entitiy_capabilities.vala
+++ b/xmpp-vala/src/module/xep/0115_entitiy_capabilities.vala
@@ -103,7 +103,7 @@ namespace Xmpp.Xep.EntityCapabilities {
     }
 
     public interface Storage : Object {
-        public abstract void store_features(string entitiy, Gee.List<string> capabilities);
-        public abstract Gee.List<string> get_features(string entitiy);
+        public abstract void store_features(string entity, Gee.List<string> capabilities);
+        public abstract Gee.List<string> get_features(string entity);
     }
 }

--- a/xmpp-vala/tests/common.vala
+++ b/xmpp-vala/tests/common.vala
@@ -27,7 +27,7 @@ void fail_if_not_error_code(ErrorFunc func, int expectedCode, string? reason = n
         func();
         fail_if_reached(@"$(reason + ": " ?? "")no error thrown");
     } catch (Error e) {
-        fail_if_not_eq_int(e.code, expectedCode, @"$(reason + ": " ?? "")catched unexpected error");
+        fail_if_not_eq_int(e.code, expectedCode, @"$(reason + ": " ?? "")caught unexpected error");
     }
 }
 


### PR DESCRIPTION
Thanks `codespell`!