### PR TITLE
Check previous network state on_network_changed before reconnect.

### DIFF
--- a/libdino/src/service/connection_manager.vala
+++ b/libdino/src/service/connection_manager.vala
@@ -25,6 +25,7 @@ public class ConnectionManager {
     private Login1Manager? login1;
     private ModuleManager module_manager;
     public string? log_options;
+    private bool network_was_active;
 
     public class ConnectionError {
 
@@ -266,11 +267,15 @@ public class ConnectionManager {
     }
 
     private void on_network_changed() {
-        if (network_is_online()) {
+        bool network_online = network_is_online();
+
+        if (network_online && !network_was_active) {
             print("network online\n");
+           network_was_active = true;
             check_reconnects();
-        } else {
+        } else if (!network_online && network_was_active) {
             print("network offline\n");
+            network_was_active = false;
             foreach (Account account in connection_todo) {
                 change_connection_state(account, ConnectionState.DISCONNECTED);
             }


### PR DESCRIPTION
As we know GNetworkMonitor inform us too often about a change,
we should track and check the last state.

I noticed many "network online" messages and then clients of my partners
get a replaced by new connection message.
These messages were sent very often, like every secound and this
is confusioning the other clients, so they cannot send messages to me.

I'm not sure wether the problem is the GNetworkMonitor or the
reconnecting process.

I've problems to debug the reconnect problem because it takes some
random time until the many reconects take part.