### PR TITLE
Rename 'start chat' into 'start conversation'

### DIFF
--- a/main/data/menu_add.ui
+++ b/main/data/menu_add.ui
@@ -3,7 +3,7 @@
         <section>
             <item>
                 <attribute name="action">app.add_chat</attribute>
-                <attribute name="label" translatable="yes">Start Chat</attribute>
+                <attribute name="label" translatable="yes">Start Conversation</attribute>
             </item>
         </section>
         <section>

--- a/main/src/ui/add_conversation/select_contact_dialog.vala
+++ b/main/src/ui/add_conversation/select_contact_dialog.vala
@@ -82,7 +82,7 @@ public class AddChatDialog : SelectContactDialog {
 
     public AddChatDialog(StreamInteractor stream_interactor, Gee.List<Account> accounts) {
         base(stream_interactor, accounts);
-        title = _("Start Chat");
+        title = _("Start Conversation");
         ok_button.label = _("Start");
         selected.connect((account, jid) => {
             Conversation conversation = stream_interactor.get_module(ConversationManager.IDENTITY).create_conversation(jid, account, Conversation.Type.CHAT);

--- a/main/src/ui/unified_window.vala
+++ b/main/src/ui/unified_window.vala
@@ -172,7 +172,7 @@ public class NoAccountsPlaceholder : UnifiedWindowPlaceholder {
 public class NoConversationsPlaceholder : UnifiedWindowPlaceholder {
     public NoConversationsPlaceholder() {
         label.label = _("No active conversations");
-        primary_button.label = _("Start Chat");
+        primary_button.label = _("Start Conversation");
         secondary_button.label = _("Join Conference");
         secondary_button.visible = true;
     }


### PR DESCRIPTION
Personally I think when reading 'Join Conference' the 'Start Chat' doesn't sound so nice. I tend to think 'Start Conversation' sounds better.