### PR TITLE
Implement notification sounds

### DIFF
--- a/cmake/FindCanberra.cmake
+++ b/cmake/FindCanberra.cmake
@@ -1,0 +1,10 @@
+include(PkgConfigWithFallback)
+find_pkg_config_with_fallback(Canberra
+    PKG_CONFIG_NAME libcanberra
+    LIB_NAMES canberra
+    INCLUDE_NAMES canberra.h
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Canberra
+    REQUIRED_VARS Canberra_LIBRARY)

--- a/libdino/src/entity/conversation.vala
+++ b/libdino/src/entity/conversation.vala
@@ -101,6 +101,10 @@ public class Conversation : Object {
         return notify_setting != NotifySetting.DEFAULT ? notify_setting : get_notification_default_setting(stream_interactor);
     }
 
+    public bool get_sound_setting(StreamInteractor stream_interactor) {
+        return Application.get_default().settings.sound;
+    }
+
     public NotifySetting get_notification_default_setting(StreamInteractor stream_interactor) {
         Xmpp.XmppStream? stream = stream_interactor.get_stream(account);
         if (!Application.get_default().settings.notifications) return NotifySetting.OFF;

--- a/libdino/src/entity/settings.vala
+++ b/libdino/src/entity/settings.vala
@@ -10,6 +10,7 @@ public class Settings : Object {
         send_typing_ = col_to_bool_or_default("send_typing", true);
         send_marker_ = col_to_bool_or_default("send_marker", true);
         notifications_ = col_to_bool_or_default("notifications", true);
+        sound_ = col_to_bool_or_default("sound", true);
         convert_utf8_smileys_ = col_to_bool_or_default("convert_utf8_smileys", true);
 
         current_width = col_to_int_or_default("window_width", 1200);
@@ -53,6 +54,15 @@ public class Settings : Object {
         set {
             db.settings.insert().or("REPLACE").value(db.settings.key, "notifications").value(db.settings.value, value.to_string()).perform();
             notifications_ = value;
+        }
+    }
+
+    private bool sound_;
+    public bool sound {
+        get { return sound_; }
+        set {
+            db.settings.insert().or("REPLACE").value(db.settings.key, "sound").value(db.settings.value, value.to_string()).perform();
+            sound_ = value;
         }
     }
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -9,6 +9,7 @@ find_packages(MAIN_PACKAGES REQUIRED
     GModule
     GObject
     GTK3>=3.22
+    Canberra
 )
 
 set(RESOURCE_LIST

--- a/main/data/settings_dialog.ui
+++ b/main/data/settings_dialog.ui
@@ -54,13 +54,25 @@
                             </packing>
                         </child>
                         <child>
+                            <object class="GtkCheckButton" id="sound_checkbutton">
+                                <property name="label" translatable="yes">Play a sound when a new message arrives</property>
+                                <property name="visible">True</property>
+                            </object>
+                            <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">3</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
+                            </packing>
+                        </child>
+                        <child>
                             <object class="GtkCheckButton" id="emoji_checkbutton">
                                 <property name="label" translatable="yes">Convert smileys to emojis</property>
                                 <property name="visible">True</property>
                             </object>
                             <packing>
                                 <property name="left_attach">0</property>
-                                <property name="top_attach">3</property>
+                                <property name="top_attach">4</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                             </packing>

--- a/main/src/ui/notifications.vala
+++ b/main/src/ui/notifications.vala
@@ -14,10 +14,13 @@ public class Notifications : Object {
     private HashMap<Conversation, Notification> notifications = new HashMap<Conversation, Notification>(Conversation.hash_func, Conversation.equals_func);
     private Set<string>? active_conversation_ids = null;
     private Set<string>? active_ids = new HashSet<string>();
+    private Canberra.Context sound_context;
 
     public Notifications(StreamInteractor stream_interactor, Gtk.Window window) {
         this.stream_interactor = stream_interactor;
         this.window = window;
+
+        Canberra.Context.create(out sound_context);
 
         stream_interactor.get_module(ChatInteraction.IDENTITY).focused_in.connect((focused_conversation) => {
             if (active_conversation_ids == null) {
@@ -67,6 +70,11 @@ public class Notifications : Object {
             window.get_application().send_notification(conversation.id.to_string(), notifications[conversation]);
             active_conversation_ids.add(conversation.id.to_string());
             window.urgency_hint = true;
+        }
+        if (conversation.get_sound_setting(stream_interactor)) {
+            sound_context.play (0,
+                Canberra.PROP_EVENT_ID, "message-new-instant",
+                Canberra.PROP_EVENT_DESCRIPTION, "New Dino message");
         }
     }
 

--- a/main/src/ui/settings_dialog.vala
+++ b/main/src/ui/settings_dialog.vala
@@ -8,6 +8,7 @@ class SettingsDialog : Dialog {
     [GtkChild] private CheckButton typing_checkbutton;
     [GtkChild] private CheckButton marker_checkbutton;
     [GtkChild] private CheckButton notification_checkbutton;
+    [GtkChild] private CheckButton sound_checkbutton;
     [GtkChild] private CheckButton emoji_checkbutton;
 
     Dino.Entities.Settings settings = Dino.Application.get_default().settings;
@@ -18,11 +19,13 @@ class SettingsDialog : Dialog {
         typing_checkbutton.active = settings.send_typing;
         marker_checkbutton.active = settings.send_marker;
         notification_checkbutton.active = settings.notifications;
+        sound_checkbutton.active = settings.sound;
         emoji_checkbutton.active = settings.convert_utf8_smileys;
 
         typing_checkbutton.toggled.connect(() => { settings.send_typing = typing_checkbutton.active; } );
         marker_checkbutton.toggled.connect(() => { settings.send_marker = marker_checkbutton.active; } );
         notification_checkbutton.toggled.connect(() => { settings.notifications = notification_checkbutton.active; } );
+        sound_checkbutton.toggled.connect(() => { settings.sound = sound_checkbutton.active; } );
         emoji_checkbutton.toggled.connect(() => { settings.convert_utf8_smileys = emoji_checkbutton.active; });
     }
 }


### PR DESCRIPTION
Play the systems default instant messaging message sound (message-new-instant)
whenever a notification is shown, if toggled on (also add a new setting for notification sound).
This adresses issue #61.

I have no previous experience with Vala and am aware, that this might not be the best approach to implement this feature, so please tell me, how to improve it ...