### PR TITLE
Change offline users' avatar to grayscale in the “add conversation list”

### DIFF
--- a/main/data/add_conversation/list_row.ui
+++ b/main/data/add_conversation/list_row.ui
@@ -10,7 +10,7 @@
                 <property name="visible">True</property>
                 <child>
                     <object class="DinoUiAvatarImage" id="image">
-                        <property name="allow_gray">False</property>
+                        <property name="allow_gray">True</property>
                         <property name="height">30</property>
                         <property name="width">30</property>
                         <property name="valign">center</property>


### PR DESCRIPTION
It makes the behavior consistent with the conversations list and makes online
users easier to spot when starting a conversation.