### PR TITLE
Support incoming encrypted HTTP upload file transfers with aesgcm URI scheme

### DIFF
--- a/plugins/http-files/src/file_provider.vala
+++ b/plugins/http-files/src/file_provider.vala
@@ -40,12 +40,13 @@ public class FileProvider : Dino.FileProvider, Object {
 
         public override async bool run(Entities.Message message, Xmpp.MessageStanza stanza, Conversation conversation) {
             if (!outer.url_regex.match(message.body)) return false;
+            string url = message.body.strip();
             Jid relevant_jid = stream_interactor.get_module(MucManager.IDENTITY).get_real_jid(message.from, conversation.account) ?? conversation.counterpart;
             bool in_roster = stream_interactor.get_module(RosterManager.IDENTITY).get_roster_item(conversation.account, relevant_jid) != null;
             if (message.direction == Message.DIRECTION_RECEIVED && !in_roster) return false;
 
             string? oob_url = Xmpp.Xep.OutOfBandData.get_url_from_message(message.stanza);
-            if (oob_url != null && oob_url == message.body) {
+            if (oob_url != null && oob_url.strip() == url || url.has_prefix("aesgcm")) {
                 yield outer.download_url(message, conversation);
             }
             return false;

--- a/plugins/http-files/src/file_provider.vala
+++ b/plugins/http-files/src/file_provider.vala
@@ -54,22 +54,22 @@ public class FileProvider : Dino.FileProvider, Object {
 
     private async bool download_url(Message message, Conversation conversation) {
         bool success = false;
+        string original_url = message.body.strip();
+        string url = this.stream_interactor.get_module(FileManager.IDENTITY).rewrite_incoming_url(message.body.strip());
         var session = new Soup.Session();
-        var head_message = new Soup.Message("HEAD", message.body);
+        var head_message = new Soup.Message("HEAD", url);
         if (head_message != null) {
             SourceFunc callback = download_url.callback;
             session.send_async.begin(head_message, null, (obj, res) => {
                 string? content_type = null, content_length = null;
-                print(message.body + ":\n");
                 head_message.response_headers.foreach((name, val) => {
-                    print(name + " " + val + "\n");
                     if (name == "Content-Type") content_type = val;
                     if (name == "Content-Length") content_length = val;
                 });
                 if (content_length != null && int.parse(content_length) < 5000000) {
                     FileTransfer file_transfer = new FileTransfer();
                     try {
-                        Soup.Request request = session.request(message.body);
+                        Soup.Request request = session.request(url);
                         request.send_async.begin(null, (obj, res) => {
                             try {
                                 file_transfer.input_stream = request.send_async.end(res);
@@ -84,12 +84,12 @@ public class FileProvider : Dino.FileProvider, Object {
                             file_transfer.time = message.time;
                             file_transfer.local_time = message.local_time;
                             file_transfer.direction = message.direction;
-                            file_transfer.file_name = message.body.substring(message.body.last_index_of("/") + 1);
+                            file_transfer.file_name = url.substring(url.last_index_of("/") + 1);
                             file_transfer.mime_type = content_type;
                             file_transfer.size = int.parse(content_length);
                             file_transfer.state = FileTransfer.State.NOT_STARTED;
                             file_transfer.provider = 0;
-                            file_transfer.info = message.id.to_string();
+                            file_transfer.info = message.id.to_string() + ":" + original_url;
                             file_incoming(file_transfer);
                             success = true;
                             Idle.add((owned)callback);

--- a/plugins/omemo/CMakeLists.txt
+++ b/plugins/omemo/CMakeLists.txt
@@ -35,6 +35,8 @@ SOURCES
     src/database.vala
     src/encrypt_state.vala
     src/encryption_list_entry.vala
+    src/in_file_processor.vala
+    src/in_url_rewriter.vala
     src/manager.vala
     src/message_flag.vala
     src/plugin.vala

--- a/plugins/omemo/src/in_file_processor.vala
+++ b/plugins/omemo/src/in_file_processor.vala
@@ -1,0 +1,60 @@
+using Dino.Entities;
+using Signal;
+
+namespace Dino.Plugins.Omemo {
+
+public class InFileProcessor : IncommingFileProcessor, Object {
+    private Regex url_regex;
+
+    public InFileProcessor () {
+        this.url_regex = new Regex("""^aesgcm://(.*)#(([A-Fa-f0-9]{2}){48}|([A-Fa-f0-9]{2}){44})$""");
+    }
+
+    public bool can_process(FileTransfer file_transfer) {
+        string url = file_transfer.info.substring(file_transfer.info.index_of(":")+1);
+        return this.url_regex.match(url);
+    }
+
+    public void process(FileTransfer file_transfer) {
+        try {
+            // Decode IV and key
+            MatchInfo match_info;
+            string url = file_transfer.info.substring(file_transfer.info.index_of(":")+1);
+            this.url_regex.match(url, 0, out match_info);
+            uint8[] iv_and_key = hex_to_bin(match_info.fetch(2).up());
+            uint8[] iv, key;
+            if (iv_and_key.length == 44) {
+                iv = iv_and_key[0:12];
+                key = iv_and_key[12:44];
+            } else {
+                iv = iv_and_key[0:16];
+                key = iv_and_key[16:48];
+            }
+
+            // Read data
+            uint8[] buf = new uint8[256];
+            Array<uint8> data = new Array<uint8>(false, true, 0);
+            size_t len = -1;
+            do {
+                len = file_transfer.input_stream.read(buf);
+                data.append_vals(buf, (uint) len);
+            } while(len > 0);
+            // Decrypt
+            file_transfer.input_stream = new MemoryInputStream.from_data(aes_decrypt(Cipher.AES_GCM_NOPADDING, key, iv, data.data));
+            file_transfer.encryption = Encryption.OMEMO;
+        } catch (Error e) {
+            file_transfer.state = FileTransfer.State.FAILED;
+        }
+    }
+
+  private uint8[] hex_to_bin(string hex) {
+    uint8[] bin = new uint8[hex.length / 2];
+    const string HEX = "0123456789ABCDEF";
+    for (int i = 0; i < hex.length / 2; i++)
+      bin[i] = (uint8) (HEX.index_of_char(hex[i*2]) << 4) | HEX.index_of_char(hex[i*2+1]);
+    return bin;
+  }
+
+}
+
+}

--- a/plugins/omemo/src/in_url_rewriter.vala
+++ b/plugins/omemo/src/in_url_rewriter.vala
@@ -1,0 +1,23 @@
+using Dino.Entities;
+
+namespace Dino.Plugins.Omemo {
+
+public class InURLRewriter : IncomingURLRewriter, Object {
+    private Regex url_regex;
+
+    public InURLRewriter () {
+        this.url_regex = new Regex("""^aesgcm://(.*)#(([A-Fa-f0-9]{2}){48}|([A-Fa-f0-9]{2}){44})$""");
+    }
+
+    public string? rewrite(string url) {
+      print("Should I rewrite URL?\n");
+      MatchInfo info;
+      if (this.url_regex.match(url, 0, out info)) {
+        return "https://" + info.fetch(1);
+      } else {
+        return null;
+      }
+    }
+}
+
+}

--- a/plugins/omemo/src/plugin.vala
+++ b/plugins/omemo/src/plugin.vala
@@ -43,6 +43,8 @@ public class Plugin : RootInterface, Object {
             list.add(new StreamModule());
         });
         Manager.start(this.app.stream_interactor, db);
+        app.stream_interactor.get_module(FileManager.IDENTITY).add_incomming_processor(new InFileProcessor());
+        app.stream_interactor.get_module(FileManager.IDENTITY).add_incoming_url_rewriter(new InURLRewriter());
 
         string locales_dir;
         if (app.search_path_generator != null) {


### PR DESCRIPTION
Many XMPP clients supporting OMEMO use a non-standard URI scheme for end-to-end encrypted files through HTTP upload.
This pull request implements receiving such file transfers (outgoing file transfers are still *unencrypted* even in an OMEMO-enabled conversation).
I had to add new interfaces, since the HTTP upload and OMEMO plugins are independent. I am not too sure about those changes, but I have not found a better way.