### PR TITLE
flatpak: Add a build manifest

### DIFF
--- a/im.dino.Dino.json
+++ b/im.dino.Dino.json
@@ -1,0 +1,52 @@
+{
+    "id": "im.dino.Dino",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.30",
+    "sdk": "org.gnome.Sdk",
+    "command": "dino",
+    "finish-args": [
+        "--socket=x11",
+        "--share=ipc",
+        "--socket=wayland",
+        "--share=network",
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "modules": [
+        {
+            "name": "libgee",
+            "make-install-args": [
+                "girdir=/app/share/gir-1.0",
+                "typelibdir=/app/lib/girepository-1.0"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libgee/0.20/libgee-0.20.1.tar.xz",
+                    "sha256": "bb2802d29a518e8c6d2992884691f06ccfcc25792a5686178575c7111fea4630"
+                }
+            ]
+        },
+        {
+            "name": "libqrencode",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://fukuchi.org/works/qrencode/qrencode-4.0.2.tar.bz2",
+                    "sha256": "c9cb278d3b28dcc36b8d09e8cad51c0eca754eb004cb0247d4703cb4472b58b4"
+                }
+            ]
+        },
+        {
+            "name": "dino",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/dino/dino.git"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
With this one can build Dino from master with `flatpak-builder`.

---

If you want to try this out, follow this procedure:

1.  install Flatpak and add the Flathub repository (see [instructions](https://flatpak.org/setup/))
2.  install the `flatpak-builder` package
3.  checkout this branch, then build and install Dino:
    ```
    $ flatpak-builder --install-deps-from=flathub --install --force-clean --ccache app im.dino.Dino.json
    ```
4.  you can now run Dino from your desktop by clicking on the icon, or with the command line:
    ```
    $ flatpak run im.dino.Dino
    ```

---

Do note that OpenPGP will not work with this build. That's because the app is sandboxed and as such doesn't have access to `~/.gnupg/`.

I didn't grant it access because the only way to make this work (that I could find) is to give the app read-write access to the whole `~/.gnupg/` folder, which is a pretty big security hole.

It's not worse than non-sandboxed apps of course (they can do whatever they want anywhere in your home directory), so if you feel like the functionality is more important than the security concern (and it probably is… what good is security if you can't do anything?) then I'm happy to edit this pull requestand make it work.

I do think it's important to consider the problem and think about it though, which is why I didn't do it in the initial submission.

---

One thing that can be done with this is to have a server somewhere build the Flatpak every time the master branch is updated, and publish the app in a repo somewhere under https://dino.im/.

I'll be happy to help set this up if you're interested (it requires a few more steps than I detailed above), but this would probably come later, let's not get ahead of ourselves.

Alternatively, once Dino has a release I volunteer to get it on Flathub, if that's what you want. :slightly_smiling_face: 