### PR TITLE
Fix parsing of multiple --(enable|disable)-plugin options

### DIFF
--- a/configure
+++ b/configure
@@ -103,8 +103,8 @@ EOF
 while true; do
     case "$1" in
         --prefix ) PREFIX="$2"; shift; shift ;;
-        --enable-plugin ) if [ "$ENABLED_PLUGINS" == "" ]; then ENABLED_PLUGINS="$2"; else ENABLED_PLUGINS="ENABLED_PLUGINS;$2"; fi; shift; shift ;;
-        --disable-plugin ) if [ "$DISABLED_PLUGINS" == "" ]; then DISABLED_PLUGINS="$2"; else DISABLED_PLUGINS="DISABLED_PLUGINS;$2"; fi; shift; shift ;;
+        --enable-plugin ) if [ "$ENABLED_PLUGINS" == "" ]; then ENABLED_PLUGINS="$2"; else ENABLED_PLUGINS="$ENABLED_PLUGINS;$2"; fi; shift; shift ;;
+        --disable-plugin ) if [ "$DISABLED_PLUGINS" == "" ]; then DISABLED_PLUGINS="$2"; else DISABLED_PLUGINS="$DISABLED_PLUGINS;$2"; fi; shift; shift ;;
         --valac ) VALA_EXECUTABLE="$2"; shift; shift ;;
         --valac-flags ) VALAC_FLAGS="$2"; shift; shift ;;
         --lib-suffix ) LIB_SUFFIX="$2"; shift; shift ;;


### PR DESCRIPTION
Due to missing `$` variables `$ENABLED_PLUGINS` and `$DISABLED_PLUGINS` were not evaluated.