### PR TITLE
Enable secure_delete PRAGMA on SQLite databases

### DIFF
--- a/libdino/src/service/database.vala
+++ b/libdino/src/service/database.vala
@@ -202,6 +202,9 @@ public class Database : Qlite.Database {
         try {
             exec("PRAGMA synchronous=0");
         } catch (Error e) { }
+        try {
+            exec("PRAGMA secure_delete=1");
+        } catch (Error e) { }
     }
 
     public override void migrate(long oldVersion) {

--- a/plugins/omemo/src/database.vala
+++ b/plugins/omemo/src/database.vala
@@ -119,6 +119,9 @@ public class Database : Qlite.Database {
         try {
             exec("PRAGMA synchronous=0");
         } catch (Error e) { }
+        try {
+            exec("PRAGMA secure_delete=1");
+        } catch (Error e) { }
     }
 
     public override void migrate(long oldVersion) {


### PR DESCRIPTION
It is especially important for OMEMO database, as it stores *ephemeral* keys