### PR TITLE
Fix session creation sometimes failing

### DIFF
--- a/plugins/omemo/src/stream_module.vala
+++ b/plugins/omemo/src/stream_module.vala
@@ -197,6 +197,7 @@ public class StreamModule : XmppStreamModule {
         if (active_bundle_requests.add(jid.bare_jid.to_string() + @":$device_id")) {
             if (Plugin.DEBUG) print(@"OMEMO: Asking for bundle from $(jid.bare_jid.to_string()):$device_id\n");
             stream.get_module(Pubsub.Module.IDENTITY).request(stream, jid.bare_jid, @"$NODE_BUNDLES:$device_id", (stream, jid, id, node) => {
+                stream.get_module(IDENTITY).active_bundle_requests.remove(jid.bare_jid.to_string() + @":$device_id");
                 bundle_fetched(jid, device_id, new Bundle(node));
             });
         }


### PR DESCRIPTION
When `fetch_bundle` was called, the bundle request would never get removed, resulting in us being unable to fetch the bundle for session creation.

There still remains a separate bug where the bundle doesn't get fetched if the recipient is offline.