### PR TITLE
Display room name in conversation selector and conversation titlebar

### DIFF
--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -129,6 +129,11 @@ public class MucManager : StreamInteractionModule, Object {
         return is_groupchat(jid.bare_jid, account) && jid.is_full();
     }
 
+    public bool is_groupchat_pm(Jid jid, Account account) {
+        Conversation? conversation = stream_interactor.get_module(ConversationManager.IDENTITY).get_conversation(jid, account);
+        return jid.is_full() && conversation != null && conversation.type_ == Conversation.Type.GROUPCHAT_PM;
+    }
+
     public void get_bookmarks(Account account, owned Xep.Bookmarks.Module.OnResult listener) {
         XmppStream? stream = stream_interactor.get_stream(account);
         if (stream != null) stream.get_module(Xep.Bookmarks.Module.IDENTITY).get_conferences(stream, (owned)listener);

--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -12,6 +12,7 @@ public class MucManager : StreamInteractionModule, Object {
     public signal void enter_error(Account account, Jid jid, Xep.Muc.MucEnterError error);
     public signal void left(Account account, Jid jid);
     public signal void subject_set(Account account, Jid jid, string? subject);
+    public signal void room_name_set(Account account, Jid jid, string? room_name);
     public signal void bookmarks_updated(Account account, Gee.List<Xep.Bookmarks.Conference> conferences);
 
     private StreamInteractor stream_interactor;
@@ -42,7 +43,7 @@ public class MucManager : StreamInteractionModule, Object {
             Entities.Message? last_message = stream_interactor.get_module(MessageStorage.IDENTITY).get_last_message(conversation);
             if (last_message != null) history_since = last_message.time;
         }
-        
+
         stream.get_module(Xep.Muc.Module.IDENTITY).enter(stream, jid.bare_jid, nick_, password, history_since);
     }
 
@@ -241,6 +242,9 @@ public class MucManager : StreamInteractionModule, Object {
         });
         stream_interactor.module_manager.get_module(account, Xep.Muc.Module.IDENTITY).subject_set.connect( (stream, subject, jid) => {
             subject_set(account, jid, subject);
+        });
+        stream_interactor.module_manager.get_module(account, Xep.Muc.Module.IDENTITY).room_name_set.connect( (stream, jid, room_name) => {
+            room_name_set(account, jid, room_name);
         });
         stream_interactor.module_manager.get_module(account, Xep.Bookmarks.Module.IDENTITY).received_conferences.connect( (stream, conferences) => {
             sync_autojoin_active(account, conferences);

--- a/main/src/ui/conversation_selector/conversation_row.vala
+++ b/main/src/ui/conversation_selector/conversation_row.vala
@@ -61,7 +61,7 @@ public abstract class ConversationRow : ListBoxRow {
         update_read();
     }
 
-    protected void update_name_label(string? new_name = null) {
+    protected void update_name_label() {
         name_label.label = Util.get_conversation_display_name(stream_interactor, conversation);
     }
 

--- a/main/src/ui/conversation_selector/groupchat_row.vala
+++ b/main/src/ui/conversation_selector/groupchat_row.vala
@@ -18,6 +18,13 @@ public class GroupchatRow : ConversationRow {
                 update_name_label();
             }
         });
+
+        stream_interactor.get_module(MucManager.IDENTITY).subject_set.connect((account, jid, room_name) => {
+            if (conversation != null && conversation.counterpart.equals_bare(jid) && conversation.account.equals(account)) {
+                // the conversation display name may change if no room name is set
+                update_name_label();
+            }
+        });
     }
 
     protected override void update_message_label() {

--- a/main/src/ui/conversation_selector/groupchat_row.vala
+++ b/main/src/ui/conversation_selector/groupchat_row.vala
@@ -12,6 +12,12 @@ public class GroupchatRow : ConversationRow {
         closed.connect(() => {
             stream_interactor.get_module(MucManager.IDENTITY).part(conversation.account, conversation.counterpart);
         });
+
+        stream_interactor.get_module(MucManager.IDENTITY).room_name_set.connect((account, jid, room_name) => {
+            if (conversation != null && conversation.counterpart.equals_bare(jid) && conversation.account.equals(account)) {
+                update_name_label();
+            }
+        });
     }
 
     protected override void update_message_label() {

--- a/main/src/ui/conversation_titlebar/view.vala
+++ b/main/src/ui/conversation_titlebar/view.vala
@@ -35,35 +35,36 @@ public class ConversationTitlebar : Gtk.HeaderBar {
 
         stream_interactor.get_module(MucManager.IDENTITY).room_name_set.connect((account, jid, room_name) => {
             if (conversation != null && conversation.counterpart.equals_bare(jid) && conversation.account.equals(account)) {
-                update_title();
+                update_titlebar();
             }
         });
 
         stream_interactor.get_module(MucManager.IDENTITY).subject_set.connect((account, jid, subject) => {
             if (conversation != null && conversation.counterpart.equals_bare(jid) && conversation.account.equals(account)) {
-                update_subtitle();
+                update_titlebar();
             }
         });
     }
 
     public void initialize_for_conversation(Conversation conversation) {
         this.conversation = conversation;
-        update_title();
-        update_subtitle();
+        update_titlebar();
 
         foreach (Plugins.ConversationTitlebarWidget widget in widgets) {
             widget.set_conversation(conversation);
         }
     }
 
-    private void update_title() {
-        set_title(Util.get_conversation_display_name(stream_interactor, conversation));
-    }
+    private void update_titlebar() {
+        string conversation_display_name = Util.get_conversation_display_name(stream_interactor, conversation);
+        set_title(conversation_display_name);
 
-    private void update_subtitle() {
         if (conversation.type_ == Conversation.Type.GROUPCHAT) {
             string groupchat_subject = stream_interactor.get_module(MucManager.IDENTITY).get_groupchat_subject(conversation.counterpart, conversation.account);
-            set_subtitle(groupchat_subject);
+            set_subtitle(groupchat_subject != conversation_display_name ? groupchat_subject : null);
+        } else {
+            // unset subtitle for non-groupchat conversations
+            set_subtitle(null);
         }
     }
 }

--- a/main/src/ui/conversation_titlebar/view.vala
+++ b/main/src/ui/conversation_titlebar/view.vala
@@ -33,9 +33,15 @@ public class ConversationTitlebar : Gtk.HeaderBar {
         }
 
 
+        stream_interactor.get_module(MucManager.IDENTITY).room_name_set.connect((account, jid, room_name) => {
+            if (conversation != null && conversation.counterpart.equals_bare(jid) && conversation.account.equals(account)) {
+                update_title();
+            }
+        });
+
         stream_interactor.get_module(MucManager.IDENTITY).subject_set.connect((account, jid, subject) => {
             if (conversation != null && conversation.counterpart.equals_bare(jid) && conversation.account.equals(account)) {
-                update_subtitle(subject);
+                update_subtitle();
             }
         });
     }
@@ -54,14 +60,10 @@ public class ConversationTitlebar : Gtk.HeaderBar {
         set_title(Util.get_conversation_display_name(stream_interactor, conversation));
     }
 
-    private void update_subtitle(string? subtitle = null) {
-        if (subtitle != null) {
-            set_subtitle(subtitle);
-        } else if (conversation.type_ == Conversation.Type.GROUPCHAT) {
-            string subject = stream_interactor.get_module(MucManager.IDENTITY).get_groupchat_subject(conversation.counterpart, conversation.account);
-            set_subtitle(subject != "" ? subject : null);
-        } else {
-            set_subtitle(null);
+    private void update_subtitle() {
+        if (conversation.type_ == Conversation.Type.GROUPCHAT) {
+            string groupchat_subject = stream_interactor.get_module(MucManager.IDENTITY).get_groupchat_subject(conversation.counterpart, conversation.account);
+            set_subtitle(groupchat_subject);
         }
     }
 }

--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -53,18 +53,26 @@ public static string color_for_show(string show) {
 
 public static string get_conversation_display_name(StreamInteractor stream_interactor, Conversation conversation) {
     if (conversation.type_ == Conversation.Type.GROUPCHAT_PM) {
-        return conversation.counterpart.resourcepart + " from " + get_display_name(stream_interactor, conversation.counterpart.bare_jid, conversation.account);
+        return conversation.counterpart.resourcepart + " from " + get_display_name(stream_interactor, conversation.counterpart, conversation.account);
     }
     return get_display_name(stream_interactor, conversation.counterpart, conversation.account);
 }
 
 public static string get_display_name(StreamInteractor stream_interactor, Jid jid, Account account) {
-    if (stream_interactor.get_module(MucManager.IDENTITY).is_groupchat(jid, account)) {
+    if (stream_interactor.get_module(MucManager.IDENTITY).is_groupchat(jid, account) ||
+        stream_interactor.get_module(MucManager.IDENTITY).is_groupchat_pm(jid, account)) {
         string room_name = stream_interactor.get_module(MucManager.IDENTITY).get_room_name(account, jid);
-        if (room_name != null) {
+        // only return room name if it's not null and not the localpart of the rooms jid
+        if (room_name != null && room_name != jid.localpart) {
             return room_name;
         }
-        return jid.bare_jid.to_string();
+        // use subject if room name is not set
+        string room_subject = stream_interactor.get_module(MucManager.IDENTITY).get_groupchat_subject(jid, account);
+        if (room_subject != null) {
+            return room_subject;
+        }
+        // use jid localpart if both room name and subject are not set
+        return jid.localpart;
     } else if (stream_interactor.get_module(MucManager.IDENTITY).is_groupchat_occupant(jid, account)) {
         return jid.resourcepart;
     } else {

--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -59,7 +59,13 @@ public static string get_conversation_display_name(StreamInteractor stream_inter
 }
 
 public static string get_display_name(StreamInteractor stream_interactor, Jid jid, Account account) {
-    if (stream_interactor.get_module(MucManager.IDENTITY).is_groupchat_occupant(jid, account)) {
+    if (stream_interactor.get_module(MucManager.IDENTITY).is_groupchat(jid, account)) {
+        string room_name = stream_interactor.get_module(MucManager.IDENTITY).get_room_name(account, jid);
+        if (room_name != null) {
+            return room_name;
+        }
+        return jid.bare_jid.to_string();
+    } else if (stream_interactor.get_module(MucManager.IDENTITY).is_groupchat_occupant(jid, account)) {
         return jid.resourcepart;
     } else {
         if (jid.equals_bare(account.bare_jid)) {


### PR DESCRIPTION
Follow-up of #341.

This changes the display name of MUCs to the `room name`. If a `subject` is present, it is shown as a subtitle in the conversation titlebar. Otherwise, only the `room name` is shown.

Before:
![image](https://user-images.githubusercontent.com/7175914/44315284-f9b48200-a422-11e8-80e4-075dfaccbfaa.png)
![image](https://user-images.githubusercontent.com/7175914/44315303-21a3e580-a423-11e8-9db4-1ad85e1bd888.png)

After:
![image](https://user-images.githubusercontent.com/7175914/44315476-d8549580-a424-11e8-8913-8f952dac3a53.png)
![image](https://user-images.githubusercontent.com/7175914/44315485-ef938300-a424-11e8-8f73-3bd885569cbb.png)

