### PR TITLE
Clears the search string when search button emits toggle signal

### DIFF
--- a/main/src/ui/conversation_selector/view.vala
+++ b/main/src/ui/conversation_selector/view.vala
@@ -25,6 +25,10 @@ public class View : Box {
         search_entry.set_text("");
     }
 
+    public void clear_search_string() {
+        search_entry.set_text("");
+    }
+
     private void refilter() {
         string[]? values = null;
         string str = search_entry.get_text ();

--- a/main/src/ui/unified_window.vala
+++ b/main/src/ui/unified_window.vala
@@ -51,6 +51,7 @@ public class UnifiedWindow : Window {
         conversations_placeholder.primary_button.clicked.connect(() => { get_application().activate_action("add_chat", null); });
         conversations_placeholder.secondary_button.clicked.connect(() => { get_application().activate_action("add_conference", null); });
         filterable_conversation_list.conversation_list.conversation_selected.connect(on_conversation_selected);
+        conversation_list_titlebar.search_button.toggled.connect(filterable_conversation_list.clear_search_string);
         conversation_list_titlebar.conversation_opened.connect(on_conversation_selected);
 
         check_stack();


### PR DESCRIPTION
As of now clicking the search button, typing in text and clicking again
leaves the chat filtered. With this edit once the search button is
toggled the search string gets resetted resulting in the full
conversation list being displayed.

This addresses #420

This is the first time I write vala code and one of the first I code for GUI SW, any feeedback is welcome :)

I'm not even sure this is the right approach, I tought that the signal would be the best one but the function is triggered also when first opening the search text input.

I noticed there is a [conversation_selected](https://github.com/dino/dino/blob/7def6d7ec2d330d6afe416ae148a8eeb25fe638b/main/src/ui/conversation_selector/view.vala#L24) function in view.vala but requires arguments and wasn't sure if and how I should use it