### PR TITLE
Add a white border around QR-codes

### DIFF
--- a/plugins/omemo/src/contact_details_dialog.vala
+++ b/plugins/omemo/src/contact_details_dialog.vala
@@ -58,8 +58,19 @@ public class ContactDetailsDialog : Gtk.Dialog {
             copy_button.clicked.connect(() => {Clipboard.get_default(get_display()).set_text(fingerprint, fingerprint.length);});
 
             int sid = plugin.db.identity.row_with(plugin.db.identity.account_id, account.id)[plugin.db.identity.device_id];
-            Pixbuf pixbuf = new QRcode(@"xmpp:$(account.bare_jid)?omemo-sid-$(sid)=$(fingerprint)", 2).to_pixbuf();
-            pixbuf = pixbuf.scale_simple(150, 150, InterpType.NEAREST);
+            Pixbuf qr_pixbuf = new QRcode(@"xmpp:$(account.bare_jid)?omemo-sid-$(sid)=$(fingerprint)", 2).to_pixbuf();
+            qr_pixbuf = qr_pixbuf.scale_simple(150, 150, InterpType.NEAREST);
+
+            Pixbuf pixbuf = new Pixbuf(
+                qr_pixbuf.colorspace,
+                qr_pixbuf.has_alpha,
+                qr_pixbuf.bits_per_sample,
+                170,
+                170
+            );
+            pixbuf.fill(uint32.MAX);
+            qr_pixbuf.copy_area(0, 0, 150, 150, pixbuf, 10, 10);
+
             qrcode_image.set_from_pixbuf(pixbuf);
             show_qrcode_button.clicked.connect(qrcode_popover.popup);
         }


### PR DESCRIPTION
My GTK theme has popups in a dark color by default.  This makes the QR-Codes unscannable.  To fix this, this PR adds a small white border around QR-Codes, so they are always scannable, independent from the user's theme.