### PR TITLE
Check existence of avatar hash in muc presence

### DIFF
--- a/libdino/src/service/avatar_manager.vala
+++ b/libdino/src/service/avatar_manager.vala
@@ -73,6 +73,14 @@ public class AvatarManager : StreamInteractionModule, Object {
         return null;
     }
 
+    public bool has_avatar(Account account, Jid jid) {
+        Jid jid_ = jid;
+        if (!stream_interactor.get_module(MucManager.IDENTITY).is_groupchat_occupant(jid, account)) {
+            jid_ = jid.bare_jid;
+        }
+        return user_avatars[jid_] != null || vcard_avatars[jid_] != null;
+    }
+
     public void publish(Account account, string file) {
         try {
             Pixbuf pixbuf = new Pixbuf.from_file(file);

--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -212,11 +212,6 @@ public class MucManager : StreamInteractionModule, Object {
         return null;
     }
 
-    public bool has_avatar(Jid muc_jid, Account account) {
-        Gee.List<Jid>? full_jids = stream_interactor.get_module(PresenceManager.IDENTITY).get_full_jids(muc_jid, account);
-        return full_jids != null && full_jids.contains(muc_jid);
-    }
-
     private Xep.Muc.Flag? get_muc_flag(Account account) {
         XmppStream? stream = stream_interactor.get_stream(account);
         if (stream != null) {

--- a/main/src/ui/avatar_image.vala
+++ b/main/src/ui/avatar_image.vala
@@ -206,7 +206,7 @@ public class AvatarImage : Misc {
             stream_interactor.connection_manager.connection_state_changed.connect(on_connection_changed);
             stream_interactor.get_module(RosterManager.IDENTITY).updated_roster_item.connect(on_roster_updated);
         }
-        if (muc_manager.is_groupchat(jid_, account) && !muc_manager.has_avatar(jid_, account)) {
+        if (muc_manager.is_groupchat(jid_, account) && !avatar_manager.has_avatar(account, jid_)) {
             // Groupchat without avatar
             Gee.List<Jid>? occupants = muc_manager.get_other_occupants(jid_, account);
             jid = jid_;


### PR DESCRIPTION
Previously dino would check if it ever received a presence from the bare MUC JID
to determine if a room has an avatar set. This is not enough since rooms will
send out such a presence even when no avatar is set. (Receiving presence is just
a (bad) indicator on whether or not a room supports avatars in general.)

As a result rooms that generally support avatars but don’t have one wouldn’t
show the automatically generated avatar.

This commit fixes this determination by checking with Avatar_Manager if dino
has received a hash.