### PR TITLE
display groups w/o name by list of members

### DIFF
--- a/main/src/ui/conversation_selector/conversation_row.vala
+++ b/main/src/ui/conversation_selector/conversation_row.vala
@@ -59,6 +59,11 @@ public class ConversationRow : ListBoxRow {
                         update_name_label();
                     }
                 });
+                stream_interactor.get_module(MucManager.IDENTITY).private_room_occupant_updated.connect((account, room, occupant) => {
+                    if (conversation != null && conversation.counterpart.equals_bare(room.bare_jid) && conversation.account.equals(account)) {
+                        update_name_label();
+                    }
+                });
                 break;
             case Conversation.Type.GROUPCHAT_PM:
                 break;

--- a/main/src/ui/conversation_titlebar/view.vala
+++ b/main/src/ui/conversation_titlebar/view.vala
@@ -42,6 +42,12 @@ public class ConversationTitlebar : Gtk.HeaderBar {
             }
         });
 
+        stream_interactor.get_module(MucManager.IDENTITY).private_room_occupant_updated.connect((account, room, occupant) => {
+            if (conversation != null && conversation.counterpart.equals_bare(room.bare_jid) && conversation.account.equals(account)) {
+                update_title();
+            }
+        });
+
         stream_interactor.get_module(MucManager.IDENTITY).subject_set.connect((account, jid, subject) => {
             if (conversation != null && conversation.counterpart.equals_bare(jid) && conversation.account.equals(account)) {
                 update_subtitle(subject);

--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -60,9 +60,24 @@ public static string get_conversation_display_name(StreamInteractor stream_inter
 
 public static string get_display_name(StreamInteractor stream_interactor, Jid jid, Account account) {
     if (stream_interactor.get_module(MucManager.IDENTITY).is_groupchat(jid, account)) {
-        string room_name = stream_interactor.get_module(MucManager.IDENTITY).get_room_name(account, jid);
+        MucManager muc_manager = stream_interactor.get_module(MucManager.IDENTITY);
+        string room_name = muc_manager.get_room_name(account, jid);
         if (room_name != null && room_name != jid.localpart) {
             return room_name;
+        }
+        if (muc_manager.is_private_room(account, jid)) {
+            Gee.List<Jid>? other_occupants = muc_manager.get_other_offline_members(jid, account);
+            if (other_occupants != null && other_occupants.size > 0) {
+                var builder = new StringBuilder ();
+                foreach(Jid occupant in other_occupants) {
+
+                    if (builder.len != 0) {
+                        builder.append(", ");
+                    }
+                    builder.append(get_display_name(stream_interactor, occupant, account).split(" ")[0]);
+                }
+                return builder.str;
+            }
         }
         return jid.bare_jid.to_string();
     } else if (stream_interactor.get_module(MucManager.IDENTITY).is_groupchat_occupant(jid, account)) {

--- a/xmpp-vala/src/module/xep/0045_muc/module.vala
+++ b/xmpp-vala/src/module/xep/0045_muc/module.vala
@@ -381,6 +381,7 @@ public class Module : XmppStreamModule {
                 if (jid_ != null && affiliation_ != null) {
                     stream.get_flag(Flag.IDENTITY).set_offline_member(iq.from, jid_, parse_affiliation(affiliation_));
                     ret_jids.add(jid_);
+                    received_occupant_jid(stream, iq.from, jid_);
                 }
             }
             if (listener != null) listener(stream, ret_jids);


### PR DESCRIPTION
For members-only, non-anonymous groups that do not have a name set we now
show an automatically generated name that is generated from the list of members
(offline, and online). Only the first name (before the first space) is used
to keep the generated name short.

This commit also uses the offline members list instead of the online member list
to generate avatar tiles (also only in members-only, non-anon groups.)