### PR TITLE
Use libgsasl for SASL operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Build
 * libgee-0.8 (≥ 0.10)
 * libgcrypt (For the OMEMO plugin)
 * libqrencode3 (For the OMEMO plugin)
+* libgsasl (For SASL authentication)
 * libsoup (For the HTTP files plugin)
 * SQLite3
 

--- a/cmake/FindGSasl.cmake
+++ b/cmake/FindGSasl.cmake
@@ -1,0 +1,11 @@
+include(PkgConfigWithFallback)
+find_pkg_config_with_fallback(GSasl
+    PKG_CONFIG_NAME libgsasl
+    LIB_NAMES gsasl
+    INCLUDE_NAMES gsasl.h
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GSasl
+    REQUIRED_VARS GSasl_LIBRARY
+    VERSION_VAR GSasl_VERSION)

--- a/libdino/src/service/connection_manager.vala
+++ b/libdino/src/service/connection_manager.vala
@@ -169,6 +169,9 @@ public class ConnectionManager : Object {
         stream.get_module(Sasl.Module.IDENTITY).received_auth_failure.connect((stream, node) => {
             set_connection_error(account, new ConnectionError(ConnectionError.Source.SASL, null));
         });
+        stream.get_module(Sasl.Module.IDENTITY).sasl_error.connect((stream, description) => {
+            set_connection_error(account, new ConnectionError(ConnectionError.Source.SASL, description));
+        });
         stream.get_module(Tls.Module.IDENTITY).invalid_certificate.connect(() => {
             set_connection_error(account, new ConnectionError(ConnectionError.Source.TLS, null) { reconnect_recomendation=ConnectionError.Reconnect.NEVER});
         });

--- a/xmpp-vala/CMakeLists.txt
+++ b/xmpp-vala/CMakeLists.txt
@@ -4,6 +4,7 @@ find_packages(ENGINE_PACKAGES REQUIRED
     GIO
     GLib
     GObject
+    GSasl
 )
 
 vala_precompile(ENGINE_VALA_C
@@ -78,6 +79,8 @@ GENERATE_VAPI
     xmpp-vala
 GENERATE_HEADER
     xmpp-vala
+OPTIONS
+    --vapidir=${CMAKE_CURRENT_SOURCE_DIR}/vapi
 )
 
 add_custom_target(xmpp-vala-vapi

--- a/xmpp-vala/CMakeLists.txt
+++ b/xmpp-vala/CMakeLists.txt
@@ -87,6 +87,7 @@ add_custom_target(xmpp-vala-vapi
 DEPENDS
     ${CMAKE_BINARY_DIR}/exports/xmpp-vala.vapi
     ${CMAKE_BINARY_DIR}/exports/xmpp-vala.deps
+    ${CMAKE_CURRENT_SOURCE_DIR}/vapi/libgsasl.vapi
 )
 
 add_definitions(${VALA_CFLAGS})

--- a/xmpp-vala/src/module/sasl.vala
+++ b/xmpp-vala/src/module/sasl.vala
@@ -3,23 +3,13 @@ using Gsasl;
 namespace Xmpp.Sasl {
     private const string NS_URI = "urn:ietf:params:xml:ns:xmpp-sasl";
 
-    public class Flag : XmppStreamFlag {
+    private class Flag : XmppStreamFlag {
         public static FlagIdentity<Flag> IDENTITY = new FlagIdentity<Flag>(NS_URI, "sasl");
-        public string mechanism;
-        public string name;
-        public string password;
-        public string client_nonce;
-        public uint8[] server_signature;
+        public Gsasl.Session? sasl_session;
         public bool finished = false;
 
         public override string get_ns() { return NS_URI; }
         public override string get_id() { return IDENTITY.id; }
-    }
-
-    namespace Mechanism {
-        public const string PLAIN = "PLAIN";
-        public const string SCRAM_SHA_1 = "SCRAM-SHA-1";
-        public const string SCRAM_SHA_1_PLUS = "SCRAM-SHA-1-PLUS";
     }
 
     public class Module : XmppStreamNegotiationModule {
@@ -27,11 +17,14 @@ namespace Xmpp.Sasl {
 
         public string name { get; set; }
         public string password { get; set; }
-        public bool use_full_name = false;
+        private Gsasl.Context sasl_context;
 
         public signal void received_auth_failure(XmppStream stream, StanzaNode node);
+        public signal void sasl_error(XmppStream stream, string description);
 
         public Module(string name, string password) {
+            Gsasl.Result result = Gsasl.Context.init(out this.sasl_context);
+            assert(result == Gsasl.Result.OK);
             this.name = name;
             this.password = password;
         }
@@ -46,106 +39,27 @@ namespace Xmpp.Sasl {
             stream.received_nonza.disconnect(this.received_nonza);
         }
 
-        private static size_t SHA1_SIZE = 20;
-
-        private static uint8[] hmac_sha1(uint8[] key, uint8[] data) {
-            Hmac hmac = new Hmac(ChecksumType.SHA1, key);
-            hmac.update(data);
-            uint8[] res = new uint8[SHA1_SIZE];
-            hmac.get_digest(res, ref SHA1_SIZE);
-            return res;
-        }
-
-        private static uint8[] pbkdf2_sha1(string password, uint8[] salt, uint iterations) {
-            uint8[] res = new uint8[SHA1_SIZE];
-            uint8[] last = new uint8[salt.length + 4];
-            for(int i = 0; i < salt.length; i++) {
-                last[i] = salt[i];
-            }
-            last[salt.length + 3] = 1;
-            for(int i = 0; i < iterations; i++) {
-                last = hmac_sha1((uint8[]) password.to_utf8(), last);
-                xor_inplace(res, last);
-            }
-            return res;
-        }
-
-        private static void xor_inplace(uint8[] mix, uint8[] a2) {
-            for(int i = 0; i < mix.length; i++) {
-                mix[i] = mix[i] ^ a2[i];
-            }
-        }
-
-        private static uint8[] xor(uint8[] a1, uint8[] a2) {
-            uint8[] mix = new uint8[a1.length];
-            for(int i = 0; i < a1.length; i++) {
-                mix[i] = a1[i] ^ a2[i];
-            }
-            return mix;
-        }
-
         public void received_nonza(XmppStream stream, StanzaNode node) {
-            if (node.ns_uri == NS_URI) {
-                if (node.name == "success") {
-                    Flag flag = stream.get_flag(Flag.IDENTITY);
-                    if (flag.mechanism == Mechanism.SCRAM_SHA_1) {
-                        string confirm = (string) Base64.decode(node.get_string_content());
-                        uint8[] server_signature = null;
-                        foreach(string c in confirm.split(",")) {
-                            string[] split = c.split("=", 2);
-                            if (split.length != 2) continue;
-                            switch(split[0]) {
-                                case "v": server_signature = Base64.decode(split[1]); break;
-                            }
-                        }
-                        if (server_signature == null) return;
-                        if (server_signature.length != flag.server_signature.length) return;
-                        for(int i = 0; i < server_signature.length; i++) {
-                            if (server_signature[i] != flag.server_signature[i]) return;
-                        }
-                    }
-                    stream.require_setup();
-                    flag.password = null; // Remove password from memory
-                    flag.finished = true;
-                } else if (node.name == "failure") {
+            if (node.ns_uri != NS_URI)
+                return;
+            if (node.name == "success") {
+                Flag flag = stream.get_flag(Flag.IDENTITY);
+                stream.require_setup();
+                flag.finished = true;
+            } else if (node.name == "failure") {
+                stream.remove_flag(stream.get_flag(Flag.IDENTITY));
+                received_auth_failure(stream, node);
+            } else if (node.name == "challenge" && stream.has_flag(Flag.IDENTITY)) {
+                Flag flag = stream.get_flag(Flag.IDENTITY);
+                string output;
+                Gsasl.Result result = flag.sasl_session.step64(node.get_string_content(), out output);
+                if (result != Gsasl.Result.OK && result != Gsasl.Result.NEEDS_MORE) {
                     stream.remove_flag(stream.get_flag(Flag.IDENTITY));
-                    received_auth_failure(stream, node);
-                } else if (node.name == "challenge" && stream.has_flag(Flag.IDENTITY)) {
-                    Flag flag = stream.get_flag(Flag.IDENTITY);
-                    if (flag.mechanism == Mechanism.SCRAM_SHA_1) {
-                        string challenge = (string) Base64.decode(node.get_string_content());
-                        string? server_nonce = null;
-                        uint8[] salt = null;
-                        uint iterations = 0;
-                        foreach(string c in challenge.split(",")) {
-                            string[] split = c.split("=", 2);
-                            if (split.length != 2) continue;
-                            switch(split[0]) {
-                                case "r": server_nonce = split[1]; break;
-                                case "s": salt = Base64.decode(split[1]); break;
-                                case "i": iterations = int.parse(split[1]); break;
-                            }
-                        }
-                        if (server_nonce == null || salt == null || iterations == 0) return;
-                        if (!server_nonce.has_prefix(flag.client_nonce)) return;
-                        string client_final_message_bare = @"c=biws,r=$server_nonce";
-                        uint8[] salted_password = pbkdf2_sha1(flag.password, salt, iterations);
-                        uint8[] client_key = new uint8[SHA1_SIZE];
-                        if (Gsasl.hmac_sha1(salted_password, (uint8[]) "Client Key".to_utf8(), out client_key) != Gsasl.Result.OK) return;
-                        uint8[] stored_key = new uint8[SHA1_SIZE];
-                        if (Gsasl.sha1(client_key, out stored_key) != Gsasl.Result.OK) return;
-                        string auth_message = @"n=$(flag.name),r=$(flag.client_nonce),$challenge,$client_final_message_bare";
-                        uint8[] client_signature = new uint8[SHA1_SIZE];
-                        if (Gsasl.hmac_sha1(stored_key, (uint8[]) auth_message.to_utf8(), out client_signature) != Gsasl.Result.OK) return;
-                        uint8[] client_proof = xor(client_key, client_signature);
-                        uint8[] server_key = new uint8[SHA1_SIZE];
-                        if (Gsasl.hmac_sha1(salted_password, (uint8[]) "Server Key".to_utf8(), out server_key) != Gsasl.Result.OK) return;
-                        flag.server_signature = hmac_sha1(server_key, (uint8[]) auth_message.to_utf8());
-                        string client_final_message = @"$client_final_message_bare,p=$(Base64.encode(client_proof))";
-                        stream.write(new StanzaNode.build("response", NS_URI).add_self_xmlns()
-                                .put_node(new StanzaNode.text(Base64.encode((uchar[]) (client_final_message).to_utf8()))));
-                    }
+                    sasl_error(stream, result.description());
+                    return;
                 }
+                stream.write(new StanzaNode.build("response", NS_URI).add_self_xmlns()
+                            .put_node(new StanzaNode.text(output)));
             }
         }
 
@@ -160,60 +74,33 @@ namespace Xmpp.Sasl {
                 if (mechanism.name != "mechanism" || mechanism.ns_uri != NS_URI) continue;
                 supported_mechanisms += mechanism.get_string_content();
             }
-            if (!name.contains("@")) {
-                name = "%s@%s".printf(name, stream.remote_name.to_string());
-            }
-            if (!use_full_name && name.contains("@")) {
-                var split = name.split("@");
-                if (split[1] == stream.remote_name.to_string()) {
-                    name = split[0];
-                } else {
-                    use_full_name = true;
-                }
-            }
-            string name = this.name;
-            if (!use_full_name && name.contains("@")) {
-                var split = name.split("@");
-                if (split[1] == stream.remote_name.to_string()) {
-                    name = split[0];
-                }
-            }
-            if (Mechanism.SCRAM_SHA_1 in supported_mechanisms) {
-                string normalized_password = password.normalize(-1, NormalizeMode.NFKC);
-                string client_nonce = Random.next_int().to_string("%.8x") + Random.next_int().to_string("%.8x") + Random.next_int().to_string("%.8x");
-                string initial_message = @"n=$name,r=$client_nonce";
-                stream.write(new StanzaNode.build("auth", NS_URI).add_self_xmlns()
-                        .put_attribute("mechanism", Mechanism.SCRAM_SHA_1)
-                        .put_node(new StanzaNode.text(Base64.encode((uchar[]) ("n,,"+initial_message).to_utf8()))));
-                var flag = new Flag();
-                flag.mechanism = Mechanism.SCRAM_SHA_1;
-                flag.name = name;
-                flag.password = normalized_password;
-                flag.client_nonce = client_nonce;
-                stream.add_flag(flag);
-            } else if (Mechanism.PLAIN in supported_mechanisms) {
-                stream.write(new StanzaNode.build("auth", NS_URI).add_self_xmlns()
-                                    .put_attribute("mechanism", Mechanism.PLAIN)
-                                    .put_node(new StanzaNode.text(Base64.encode(get_plain_bytes(name, password)))));
-                var flag = new Flag();
-                flag.mechanism = Mechanism.PLAIN;
-                flag.name = name;
-                stream.add_flag(flag);
-            } else {
-                stderr.printf("No supported mechanism provided by server at %s\n", stream.remote_name.to_string());
+
+            string? suggested_mechanism = this.sasl_context.client_suggest_mechanism(string.joinv(" ", supported_mechanisms));
+            if (suggested_mechanism == null) {
+                stderr.printf("No supported mechanism provided by server at %s. Offered: %s\n", stream.remote_name.to_string(), string.joinv(",", supported_mechanisms));
                 return;
             }
-        }
 
-        private static uchar[] get_plain_bytes(string name_s, string password_s) {
-            var name = name_s.to_utf8();
-            var password = password_s.to_utf8();
-            uchar[] res = new uchar[name.length + password.length + 2];
-            res[0] = 0;
-            res[name.length + 1] = 0;
-            for(int i = 0; i < name.length; i++) { res[i + 1] = (uchar) name[i]; }
-            for(int i = 0; i < password.length; i++) { res[i + name.length + 2] = (uchar) password[i]; }
-            return res;
+            var flag = new Flag();
+            Gsasl.Result result;
+            result = this.sasl_context.client_start(suggested_mechanism, out flag.sasl_session);
+            if (result != Gsasl.Result.OK) {
+                sasl_error(stream, result.description());
+                return;
+            }
+            flag.sasl_session.set_property(Gsasl.Property.AUTHID, name);
+            flag.sasl_session.set_property(Gsasl.Property.SERVICE, "xmpp");
+            flag.sasl_session.set_property(Gsasl.Property.PASSWORD, password);
+            string output;
+            result = flag.sasl_session.step64(null, out output);
+            if (result != Gsasl.Result.OK && result != Gsasl.Result.NEEDS_MORE) {
+                sasl_error(stream, result.description());
+                return;
+            }
+            stream.write(new StanzaNode.build("auth", NS_URI).add_self_xmlns()
+                         .put_attribute("mechanism", suggested_mechanism)
+                         .put_node(new StanzaNode.text(output)));
+            stream.add_flag(flag);
         }
 
         public override bool mandatory_outstanding(XmppStream stream) {

--- a/xmpp-vala/vapi/libgsasl.vapi
+++ b/xmpp-vala/vapi/libgsasl.vapi
@@ -1,0 +1,234 @@
+/* libgsasl.vapi
+ *
+ * Copyright (C) 2013  Evan Nemerson
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ * Authors:
+ * 	 Evan Nemerson <evan@coeus-group.com>
+ */
+
+[CCode (cheader_filename = "gsasl.h")]
+namespace Gsasl {
+	namespace Version {
+		[CCode (cname = "GSASL_VERSION")]
+		public const string STRING;
+		public const int MAJOR;
+		public const int MINOR;
+		public const int PATCH;
+		public const int NUMBER;
+
+		[CCode (cname = "gsasl_check_version")]
+		public static unowned string check (string req_version);
+	}
+
+	public const int MIN_MECHANISM_SIZE;
+	public const int MAX_MECHANISM_SIZE;
+	public const string VALID_MECHANISM_CHARACTERS;
+
+	[CCode (cname = "Gsasl_rc", cprefix = "GSASL_", has_type_id = false)]
+	public enum Result {
+		OK,
+		NEEDS_MORE,
+		UNKNOWN_MECHANISM,
+		MECHANISM_CALLED_TOO_MANY_TIMES,
+		MALLOC_ERROR,
+		BASE64_ERROR,
+		CRYPTO_ERROR,
+		SASLPREP_ERROR,
+		MECHANISM_PARSE_ERROR,
+		AUTHENTICATION_ERROR,
+		INTEGRITY_ERROR,
+		NO_CLIENT_CODE,
+		NO_SERVER_CODE,
+		NO_CALLBACK,
+		NO_ANONYMOUS_TOKEN,
+		NO_AUTHID,
+		NO_AUTHZID,
+		NO_PASSWORD,
+		NO_PASSCODE,
+		NO_PIN,
+		NO_SERVICE,
+		NO_HOSTNAME,
+		NO_CB_TLS_UNIQUE,
+		NO_SAML20_IDP_IDENTIFIER,
+		NO_SAML20_REDIRECT_URL,
+		NO_OPENID20_REDIRECT_URL,
+		GSSAPI_RELEASE_BUFFER_ERROR,
+		GSSAPI_IMPORT_NAME_ERROR,
+		GSSAPI_INIT_SEC_CONTEXT_ERROR,
+		GSSAPI_ACCEPT_SEC_CONTEXT_ERROR,
+		GSSAPI_UNWRAP_ERROR,
+		GSSAPI_WRAP_ERROR,
+		GSSAPI_ACQUIRE_CRED_ERROR,
+		GSSAPI_DISPLAY_NAME_ERROR,
+		GSSAPI_UNSUPPORTED_PROTECTION_ERROR,
+		KERBEROS_V5_INIT_ERROR,
+		KERBEROS_V5_INTERNAL_ERROR,
+		SHISHI_ERROR,
+		SECURID_SERVER_NEED_ADDITIONAL_PASSCODE,
+		SECURID_SERVER_NEED_NEW_PIN,
+		GSSAPI_ENCAPSULATE_TOKEN_ERROR,
+		GSSAPI_DECAPSULATE_TOKEN_ERROR,
+		GSSAPI_INQUIRE_MECH_FOR_SASLNAME_ERROR,
+		GSSAPI_TEST_OID_SET_MEMBER_ERROR,
+		GSSAPI_RELEASE_OID_SET_ERROR;
+
+		[CCode (cname = "gsasl_strerror_name")]
+		public unowned string to_string ();
+		[CCode (cname = "gsasl_strerror")]
+		public unowned string description ();
+	}
+
+	[CCode (cname = "Gsasl_qop", cprefix = "GSASL_QOP_", has_type_id = false)]
+	public enum QualityOfProtection {
+		AUTH,
+		[CCode (cname = "GSASL_QOP_AUTH")]
+		AUTHENTICATION,
+		AUTH_INT,
+		[CCode (cname = "GSASL_QOP_AUTH_INT")]
+		AUTHENTICATION_INTEGRITY,
+		AUTH_INT_CONF,
+		[CCode (cname = "GSASL_QOP_AUTH_INT_CONF")]
+		AUTHENTICATION_INTEGRITY_CONFIDENTIALITY
+	}
+
+	[CCode (cname = "Gsasl_cipher", has_type_id = false)]
+	public enum Cipher {
+		DES,
+		3DES,
+		RC4,
+		RC4_40,
+		RC4_56,
+		AES
+	}
+
+	[Flags, CCode (cname = "Gsasl_saslprep_flags", cprefix = "GSASL_", has_type_id = false)]
+	public enum PrepFlags {
+		ALLOW_UNASSIGNED
+	}
+
+	[Compact, CCode (cname = "Gsasl", lower_case_cprefix = "gsasl_", destroy_function = "gsasl_done")]
+	public class Context {
+		private Context ();
+		public static Gsasl.Result init (out Gsasl.Context ctx);
+		[CCode (cname = "gsasl_callback_set")]
+		public void set_callback (Gsasl.Callback cb);
+		[CCode (cname = "gsasl_callback")]
+		public Gsasl.Callback get_callback (Gsasl.Property prop);
+
+		public void* callback_hook {
+			[CCode (cname = "gsasl_callback_hook_set")] get;
+			[CCode (cname = "gsasl_callback_hook_get")] set;
+		}
+		[CCode (cname = "gsasl_callback_hook_get")]
+		public void* get_callback_hook ();
+		[CCode (cname = "gsasl_callback_hook_set")]
+		public void set_callback_hook (void* hook);
+
+		public Gsasl.Result client_mechlist (out string mechlist);
+		public Gsasl.Result client_support_p (string name);
+		public unowned string client_suggest_mechanism (string mechlist);
+
+		public Gsasl.Result server_mechlist (out string mechlist);
+		public Gsasl.Result server_support_p (string name);
+
+		public Gsasl.Result client_start (string mech);
+		public Gsasl.Result server_start ();
+	}
+
+	[CCode (cname = "Gsasl_session", lower_case_cprefix = "gsasl_", destroy_function = "gsasl_finish")]
+	public struct Session {
+		[CCode (cname = "gsasl_client_start", instance_pos = -1)]
+		public Session (Gsasl.Context context, string mech);
+
+		public void* hook {
+			[CCode (cname = "gsasl_session_hook_set")] get;
+			[CCode (cname = "gsasl_session_hook_get")] set;
+		}
+		[CCode (cname = "gsasl_session_hook_get")]
+		public void* get_hook ();
+		[CCode (cname = "gsasl_session_hook_set")]
+		public void set_hook (void* hook);
+
+		[CCode (cname = "gsasl_property_set")]
+		public void set_property (Gsasl.Property prop, string data);
+		[CCode (cname = "gsasl_property_set_raw")]
+		public void set_property_raw (Gsasl.Property prop, string data, size_t len);
+		[CCode (cname = "gsasl_property_get")]
+		public unowned string get_property (Gsasl.Property prop);
+		[CCode (cname = "gsasl_property_fast")]
+		public unowned string get_property_fast (Gsasl.Property prop);
+
+		public Gsasl.Result step ([CCode (array_length_type = "size_t")] uint[] input, [CCode (array_length_type = "size_t")] out uint8[] output);
+		public Gsasl.Result step64 (string b64input, out string b64output);
+
+		public Gsasl.Result encode ([CCode (array_length_type = "size_t")] uint8[] input, [CCode (array_length_type = "size_t")] out uint8[] output);
+		public Gsasl.Result decode ([CCode (array_length_type = "size_t")] uint8[] input, [CCode (array_length_type = "size_t")] out uint8[] output);
+
+		public unowned string mechanism_name ();
+	}
+
+	[CCode (cname = "Gsasl_property", cprefix = "GSASL_", has_type_id = false)]
+	public enum Property {
+		AUTHID,
+		AUTHZID,
+		PASSWORD,
+		ANONYMOUS_TOKEN,
+		SERVICE,
+		HOSTNAME,
+		GSSAPI_DISPLAY_NAME,
+		PASSCODE,
+		SUGGESTED_PIN,
+		PIN,
+		REALM,
+		DIGEST_MD5_HASHED_PASSWORD,
+		QOPS,
+		QOP,
+		SCRAM_ITER,
+		SCRAM_SALT,
+		SCRAM_SALTED_PASSWORD,
+		CB_TLS_UNIQUE,
+		SAML20_IDP_IDENTIFIER,
+		SAML20_REDIRECT_URL,
+		OPENID20_REDIRECT_URL,
+		OPENID20_OUTCOME_DATA,
+		SAML20_AUTHENTICATE_IN_BROWSER,
+		OPENID20_AUTHENTICATE_IN_BROWSER,
+		VALIDATE_SIMPLE,
+		VALIDATE_EXTERNAL,
+		VALIDATE_ANONYMOUS,
+		VALIDATE_GSSAPI,
+		VALIDATE_SECURID,
+		VALIDATE_SAML20,
+		VALIDATE_OPENID20
+	}
+
+	[CCode (cname = "Gsasl_callback_function", has_target = false)]
+	public delegate Gsasl.Result Callback (Gsasl.Context ctx, Gsasl.Session sctx, Gsasl.Property prop);
+
+	[CCode (cname = "gsasl_saslprep")]
+	public static Gsasl.Result prep (string in, Gsasl.PrepFlags flags, out string @out, out Gsasl.Result stringpreprc = null);
+
+	public static Gsasl.Result simple_getpass (string filename, string username, out string key);
+	public static Gsasl.Result base64_to ([CCode (array_length_type = "size_t")] uint[] in, [CCode (array_length_type = "size_t")] out uint8[] @out);
+	public static Gsasl.Result base64_from ([CCode (array_length_type = "size_t")] uint[] in, [CCode (array_length_type = "size_t")] out uint8[] @out);
+	public static Gsasl.Result nonce ([CCode (array_length_type = "size_t")] uint8[] data);
+	public static Gsasl.Result md5 ([CCode (array_length_type = "size_t")] uint8[] in, out uint8 @out[16]);
+	public static Gsasl.Result hmac_md5 ([CCode (array_length_type = "size_t")] uint8[] key, [CCode (array_length_type = "size_t")] uint8[] in, uint8 outhash[16]);
+	public static Gsasl.Result sha1 ([CCode (array_length_type = "size_t")] uint8[] in, out uint8 @out[20]);
+	public static Gsasl.Result hmac_sha1 ([CCode (array_length_type = "size_t")] uint8[] key, [CCode (array_length_type = "size_t")] uint8[] in, uint8 outhash[20]);
+}

--- a/xmpp-vala/vapi/libgsasl.vapi
+++ b/xmpp-vala/vapi/libgsasl.vapi
@@ -229,6 +229,6 @@ namespace Gsasl {
 	public static Gsasl.Result nonce ([CCode (array_length_type = "size_t")] uint8[] data);
 	public static Gsasl.Result md5 ([CCode (array_length_type = "size_t")] uint8[] in, out uint8 @out[16]);
 	public static Gsasl.Result hmac_md5 ([CCode (array_length_type = "size_t")] uint8[] key, [CCode (array_length_type = "size_t")] uint8[] in, uint8 outhash[16]);
-	public static Gsasl.Result sha1 ([CCode (array_length_type = "size_t")] uint8[] in, out uint8 @out[20]);
-	public static Gsasl.Result hmac_sha1 ([CCode (array_length_type = "size_t")] uint8[] key, [CCode (array_length_type = "size_t")] uint8[] in, uint8 outhash[20]);
+	public static Gsasl.Result sha1 ([CCode (array_length_type = "size_t")] uint8[] in, [CCode (array_length = false)] out uint8 @out[20]);
+	public static Gsasl.Result hmac_sha1 ([CCode (array_length_type = "size_t")] uint8[] key, [CCode (array_length_type = "size_t")] uint8[] in, [CCode (array_length = false)] out uint8 outhash[20]);
 }

--- a/xmpp-vala/vapi/libgsasl.vapi
+++ b/xmpp-vala/vapi/libgsasl.vapi
@@ -121,7 +121,7 @@ namespace Gsasl {
 		ALLOW_UNASSIGNED
 	}
 
-	[Compact, CCode (cname = "Gsasl", lower_case_cprefix = "gsasl_", destroy_function = "gsasl_done")]
+	[Compact, CCode (cname = "Gsasl", lower_case_cprefix = "gsasl_", destroy_function = "gsasl_done", has_copy_function = false)]
 	public class Context {
 		private Context ();
 		public static Gsasl.Result init (out Gsasl.Context ctx);
@@ -141,20 +141,17 @@ namespace Gsasl {
 
 		public Gsasl.Result client_mechlist (out string mechlist);
 		public Gsasl.Result client_support_p (string name);
-		public unowned string client_suggest_mechanism (string mechlist);
+		public unowned string? client_suggest_mechanism (string mechlist);
 
 		public Gsasl.Result server_mechlist (out string mechlist);
 		public Gsasl.Result server_support_p (string name);
 
-		public Gsasl.Result client_start (string mech);
-		public Gsasl.Result server_start ();
+		public Gsasl.Result client_start (string mech, out Session? session);
+		public Gsasl.Result server_start (string mech, out Session? session);
 	}
 
-	[CCode (cname = "Gsasl_session", lower_case_cprefix = "gsasl_", destroy_function = "gsasl_finish")]
-	public struct Session {
-		[CCode (cname = "gsasl_client_start", instance_pos = -1)]
-		public Session (Gsasl.Context context, string mech);
-
+	[CCode (cname = "Gsasl_session", lower_case_cprefix = "gsasl_", free_function = "gsasl_finish", has_copy_function = false), Compact]
+	public class Session {
 		public void* hook {
 			[CCode (cname = "gsasl_session_hook_set")] get;
 			[CCode (cname = "gsasl_session_hook_get")] set;
@@ -174,7 +171,7 @@ namespace Gsasl {
 		public unowned string get_property_fast (Gsasl.Property prop);
 
 		public Gsasl.Result step ([CCode (array_length_type = "size_t")] uint[] input, [CCode (array_length_type = "size_t")] out uint8[] output);
-		public Gsasl.Result step64 (string b64input, out string b64output);
+		public Gsasl.Result step64 (string? b64input, out string b64output);
 
 		public Gsasl.Result encode ([CCode (array_length_type = "size_t")] uint8[] input, [CCode (array_length_type = "size_t")] out uint8[] output);
 		public Gsasl.Result decode ([CCode (array_length_type = "size_t")] uint8[] input, [CCode (array_length_type = "size_t")] out uint8[] output);


### PR DESCRIPTION
Use gsasl for SASL operations.
    
This simplifies the SASL module somewhat, and brings in support for
more SASL mechanisms that are supported by GSASL:
https://www.gnu.org/software/gsasl/

Tested against gmail and prosody with PLAIN.