### PR TITLE
Do not ignore encrypted messages without a body tag

### DIFF
--- a/libdino/src/service/conversation_manager.vala
+++ b/libdino/src/service/conversation_manager.vala
@@ -120,7 +120,7 @@ public class ConversationManager : StreamInteractionModule, Object {
 
     private class MessageListener : Dino.MessageListener {
 
-        public string[] after_actions_const = new string[]{ "DEDUPLICATE" };
+        public string[] after_actions_const = new string[]{ "DEDUPLICATE", "FILTER_EMPTY" };
         public override string action_group { get { return "MANAGER"; } }
         public override string[] after_actions { get { return after_actions_const; } }
 

--- a/plugins/omemo/src/trust_manager.vala
+++ b/plugins/omemo/src/trust_manager.vala
@@ -247,6 +247,7 @@ public class TrustManager {
             StanzaNode? _encrypted = stanza.stanza.get_subnode("encrypted", NS_URI);
             if (_encrypted == null || MessageFlag.get_flag(stanza) != null || stanza.from == null) return false;
             StanzaNode encrypted = (!)_encrypted;
+            if (message.body == null) message.body = "[This message is OMEMO encrypted]";
             if (!Plugin.ensure_context()) return false;
             MessageFlag flag = new MessageFlag();
             stanza.add_flag(flag);


### PR DESCRIPTION
Partial fix to #473.

Partial in that it should handle correctly-encrypted incoming messages without a body tag, but won't display anything if such a message cannot be decrypted.