### PR TITLE
OS X Fixes

### DIFF
--- a/plugins/gpgme-vala/CMakeLists.txt
+++ b/plugins/gpgme-vala/CMakeLists.txt
@@ -47,6 +47,6 @@ set(CFLAGS ${VALA_CFLAGS} -I${CMAKE_CURRENT_SOURCE_DIR}/src)
 add_definitions(${CFLAGS})
 add_library(gpgme-vala ${GPGME_VALA_C} src/gpgme_fix.c)
 add_dependencies(gpgme-vala gpgme-vapi)
-target_link_libraries(gpgme-vala ${GPGME_VALA_PACKAGES} gpgme)
+target_link_libraries(gpgme-vala ${GPGME_VALA_PACKAGES} gpgme gpg-error)
 set_property(TARGET gpgme-vala PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/plugins/gpgme-vala/vapi/gpg-error.vapi
+++ b/plugins/gpgme-vala/vapi/gpg-error.vapi
@@ -1,4 +1,4 @@
-/* gcrypt.vapi
+/* gpg-error.vapi
  *
  * Copyright:
  *   2008 Jiqing Qiang

--- a/plugins/gpgme-vala/vapi/gpg-error.vapi
+++ b/plugins/gpgme-vala/vapi/gpg-error.vapi
@@ -442,6 +442,9 @@ namespace GPGError {
 		public ErrorCode code { [CCode (cname = "gpg_err_code")] get; }
 		public ErrorSource source { [CCode (cname = "gpg_err_source")] get; }
 
+		[CCode (cname = "gpgme_strerror_r")]
+		public int strerror_r(uint8[] buf);
+
 		[CCode (cname = "gpg_strerror")]
 		public unowned string to_string ();
 

--- a/plugins/gpgme-vala/vapi/gpgme.vapi
+++ b/plugins/gpgme-vala/vapi/gpgme.vapi
@@ -505,11 +505,13 @@ namespace GPG {
     [CCode (cname = "gpgme_get_engine_information")]
     public GPGError.Error get_engine_information(out EngineInfo engine_info);
 
-    [CCode (cname = "gpgme_strerror_r")]
-    public int strerror_r(GPGError.Error err, uint8[] buf);
+    public int strerror_r(GPGError.Error err, uint8[] buf) {
+        return err.strerror_r(buf);
+    }
 
-    [CCode (cname = "gpgme_strerror")]
-    public unowned string strerror(GPGError.Error err);
+    public unowned string strerror(GPGError.Error err) {
+        return err.to_string();
+    }
 
     private void throw_if_error(GPGError.Error error) throws GLib.Error {
         if (error.code != GPGError.ErrorCode.NO_ERROR) {

--- a/plugins/http-files/CMakeLists.txt
+++ b/plugins/http-files/CMakeLists.txt
@@ -24,6 +24,13 @@ PACKAGES
 
 add_definitions(${VALA_CFLAGS})
 add_library(http-files SHARED ${HTTP_FILES_VALA_C})
+if(UNIX AND APPLE)
+    # for some reason, Dino on OS X can't load plugins named .dylib,
+    # even though that's the native dlopen()able extension on OS X.
+    add_custom_command(OUTPUT http-files.so COMMAND ${CMAKE_COMMAND} -E create_symlink http-files.dylib ${CMAKE_BINARY_DIR}/plugins/http-files.so)
+    add_custom_target(http-files-symlink-workaround DEPENDS http-files.so)
+    add_dependencies(http-files http-files-symlink-workaround)
+endif(UNIX AND APPLE)
 target_link_libraries(http-files libdino ${HTTP_FILES_PACKAGES})
 set_target_properties(http-files PROPERTIES PREFIX "")
 set_target_properties(http-files PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/)

--- a/plugins/omemo/CMakeLists.txt
+++ b/plugins/omemo/CMakeLists.txt
@@ -78,6 +78,13 @@ OPTIONS
 add_definitions(${VALA_CFLAGS} -DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\" -DLOCALE_INSTALL_DIR=\"${LOCALE_INSTALL_DIR}\"  -DG_LOG_DOMAIN="OMEMO")
 add_library(omemo SHARED ${OMEMO_VALA_C} ${OMEMO_GRESOURCES_TARGET})
 add_dependencies(omemo ${GETTEXT_PACKAGE}-translations)
+if(UNIX AND APPLE)
+    # for some reason, Dino on OS X can't load plugins named .dylib,
+    # even though that's the native dlopen()able extension on OS X.
+    add_custom_command(OUTPUT omemo.so COMMAND ${CMAKE_COMMAND} -E create_symlink omemo.dylib ${CMAKE_BINARY_DIR}/plugins/omemo.so)
+    add_custom_target(omemo-symlink-workaround DEPENDS omemo.so)
+    add_dependencies(omemo omemo-symlink-workaround)
+endif(UNIX AND APPLE)
 target_link_libraries(omemo libdino signal-protocol-vala crypto-vala ${OMEMO_PACKAGES})
 set_target_properties(omemo PROPERTIES PREFIX "")
 set_target_properties(omemo PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/)

--- a/plugins/openpgp/CMakeLists.txt
+++ b/plugins/openpgp/CMakeLists.txt
@@ -56,6 +56,13 @@ GRESOURCES
 add_definitions(${VALA_CFLAGS} -DG_LOG_DOMAIN="OpenPGP" -DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\" -DLOCALE_INSTALL_DIR=\"${LOCALE_INSTALL_DIR}\")
 add_library(openpgp SHARED ${OPENPGP_VALA_C} ${OPENPGP_GRESOURCES_TARGET})
 add_dependencies(openpgp ${GETTEXT_PACKAGE}-translations)
+if(UNIX AND APPLE)
+    # for some reason, Dino on OS X can't load plugins named .dylib,
+    # even though that's the native dlopen()able extension on OS X.
+    add_custom_command(OUTPUT openpgp.so COMMAND ${CMAKE_COMMAND} -E create_symlink openpgp.dylib ${CMAKE_BINARY_DIR}/plugins/openpgp.so)
+    add_custom_target(openpgp-symlink-workaround DEPENDS openpgp.so)
+    add_dependencies(openpgp openpgp-symlink-workaround)
+endif(UNIX AND APPLE)
 target_link_libraries(openpgp libdino gpgme-vala ${OPENPGP_PACKAGES})
 set_target_properties(openpgp PROPERTIES PREFIX "")
 set_target_properties(openpgp PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/)


### PR DESCRIPTION
This fixes the

> Undefined symbols for architecture x86_64:
>  _gpg_strerror, referenced from:
>      _gpgme_throw_if_error in libgpgme-vala.a(gpgme_helper.c.o)
> ld: symbol(s) not found for architecture x86_64
> clang: error: linker command failed with exit code 1 (use -v to see invocation)

error on that's showing on OS X.