### PR TITLE
Display avatar of current account next to the chat input line

### DIFF
--- a/main/data/chat_input.ui
+++ b/main/data/chat_input.ui
@@ -9,6 +9,23 @@
             <class name="dino-chatinput"/>
         </style>
         <child>
+            <object class="GtkBox">
+                <property name="orientation">horizontal</property>
+                <property name="margin">12</property>
+                <property name="margin-top">0</property>
+                <property name="margin-end">0</property>
+                <property name="visible">True</property>
+                    <child>
+                        <object class="DinoUiAvatarImage" id="image">
+                            <property name="height">35</property>
+                            <property name="width">35</property>
+                            <property name="valign">center</property>
+                            <property name="visible">True</property>
+                        </object>
+                    </child>
+            </object>
+        </child>
+        <child>
             <object class="GtkFrame" id="frame">
                 <property name="margin">12</property>
                 <property name="margin_top">0</property>

--- a/main/src/ui/chat_input/view.vala
+++ b/main/src/ui/chat_input/view.vala
@@ -24,6 +24,7 @@ public class View : Box {
     private SmileyConverter smiley_converter;
     private EditHistory edit_history;
 
+    [GtkChild] protected AvatarImage image;
     [GtkChild] private Frame frame;
     [GtkChild] private ScrolledWindow scrolled;
     [GtkChild] public TextView text_input;
@@ -80,6 +81,8 @@ public class View : Box {
 
         if (this.conversation != null) entry_cache[this.conversation] = text_input.buffer.text;
         this.conversation = conversation;
+
+        image.set_jid(stream_interactor, conversation.account.bare_jid, conversation.account);
 
         bool upload_available = stream_interactor.get_module(FileManager.IDENTITY).is_upload_available(conversation);
         file_button.visible = upload_available;

--- a/main/src/ui/chat_input/view.vala
+++ b/main/src/ui/chat_input/view.vala
@@ -83,6 +83,7 @@ public class View : Box {
         this.conversation = conversation;
 
         image.set_jid(stream_interactor, conversation.account.bare_jid, conversation.account);
+        image.tooltip_text = conversation.account.display_name;
 
         bool upload_available = stream_interactor.get_module(FileManager.IDENTITY).is_upload_available(conversation);
         file_button.visible = upload_available;


### PR DESCRIPTION
There is currently no way to easily know which account is being used to send messages in a conversation. This can get especially problematic when the user is connected to the same MUC with multiple accounts. The issue had already been mentioned in  #383

This change allows users to know which of their accounts is used to post in the current conversation by showing the avatar of the current account next to the text input area.

As this is my first time using Vala and GTK templates, I would gladly accept improvements on the layout elements I added.