### PR TITLE
Add a tooltip when messages are in WONTSEND state

### DIFF
--- a/main/po/fr.po
+++ b/main/po/fr.po
@@ -182,6 +182,10 @@ msgstr "%d %b"
 msgid "Yesterday"
 msgstr "Hier"
 
+#: main/src/ui/conversation_summary/conversation_item_skeleton.vala:144
+msgid "Unable to send message"
+msgstr "Impossible d'envoyer le message"
+
 #: main/src/ui/conversation_selector/conversation_row.vala:266
 #: main/src/ui/conversation_summary/conversation_item_skeleton.vala:196
 #, no-c-format

--- a/main/src/ui/conversation_summary/conversation_item_skeleton.vala
+++ b/main/src/ui/conversation_summary/conversation_item_skeleton.vala
@@ -141,6 +141,10 @@ public class DefaultSkeletonHeader : Box {
                 Util.force_error_color(received_image);
                 Util.force_error_color(encryption_image);
                 Util.force_error_color(time_label);
+                string error_text = _("Unable to send message");
+                received_image.tooltip_text = error_text;
+                encryption_image.tooltip_text = error_text;
+                time_label.tooltip_text = error_text;
                 return;
             } else if (item.mark != Message.Marked.READ) {
                 all_read = false;


### PR DESCRIPTION
The warning sign and red color, while obviously synonymous with a
problem, are still a bit perplexing for the user.

This change adds a bit of clarity.

It would obviously be better to get exact cause of the problem from the
different plugins. Maybe it would be possible to add a field to the
Message class from libdino/src/entity/message.vala in order to record an
error message for every case.