### PR TITLE
Sort conversations by accounts in the selector (fix #383)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -35,6 +35,7 @@ set(RESOURCE_LIST
     conversation_list_titlebar_csd.ui
     global_search.ui
     conversation_selector/chat_row_tooltip.ui
+    conversation_selector/conversation_account_separator.ui
     conversation_selector/conversation_row.ui
     conversation_summary/image_toolbar.ui
     conversation_summary/view.ui
@@ -102,6 +103,7 @@ SOURCES
     src/ui/conversation_list_titlebar.vala
     src/ui/conversation_list_titlebar_csd.vala
     src/ui/global_search.vala
+    src/ui/conversation_selector/conversation_selector_account_sep.vala
     src/ui/conversation_selector/conversation_selector_row.vala
     src/ui/conversation_selector/conversation_selector.vala
     src/ui/conversation_summary/chat_state_populator.vala

--- a/main/data/conversation_selector/conversation_account_separator.ui
+++ b/main/data/conversation_selector/conversation_account_separator.ui
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+    <template class="DinoUiConversationSelectorAccountSep">
+        <property name="visible">True</property>
+        <child>
+            <object class="GtkRevealer" id="main_revealer">
+                <property name="transition-type">slide-down</property>
+                <property name="transition-duration">200</property>
+                <property name="reveal-child">False</property>
+                <property name="visible">True</property>
+                <child>
+                    <object class="GtkBox">
+                        <property name="orientation">horizontal</property>
+                        <property name="margin">10</property>
+                        <property name="margin-start">7</property>
+                        <property name="margin-end">14</property>
+                        <property name="visible">True</property>
+                        <child>
+                            <object class="GtkBox">
+                                <property name="valign">start</property>
+                                <property name="visible">True</property>
+                                <property name="orientation">horizontal</property>
+                                <child>
+                                    <object class="GtkLabel" id="name_label">
+                                        <property name="max_width_chars">1</property>
+                                        <property name="ellipsize">end</property>
+                                        <property name="expand">True</property>
+                                        <property name="margin-right">7</property>
+                                        <property name="xalign">0</property>
+                                        <property name="visible">True</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+            </object>
+        </child>
+    </template>
+</interface>

--- a/main/src/ui/conversation_selector/conversation_selector.vala
+++ b/main/src/ui/conversation_selector/conversation_selector.vala
@@ -13,6 +13,7 @@ public class ConversationSelector : ListBox {
     private StreamInteractor stream_interactor;
     private string[]? filter_values;
     private HashMap<Conversation, ConversationSelectorRow> rows = new HashMap<Conversation, ConversationSelectorRow>(Conversation.hash_func, Conversation.equals_func);
+    private HashMap<Account, ConversationSelectorAccountSep> seps = new HashMap<Account, ConversationSelectorAccountSep>(Account.hash_func, Account.equals_func);
 
     public ConversationSelector init(StreamInteractor stream_interactor) {
         this.stream_interactor = stream_interactor;
@@ -21,6 +22,8 @@ public class ConversationSelector : ListBox {
         stream_interactor.get_module(ConversationManager.IDENTITY).conversation_deactivated.connect(remove_conversation);
         stream_interactor.get_module(MessageProcessor.IDENTITY).message_received.connect(on_message_received);
         stream_interactor.get_module(MessageProcessor.IDENTITY).message_sent.connect(on_message_received);
+        stream_interactor.account_added.connect(add_account);
+        stream_interactor.account_removed.connect(remove_account);
         Timeout.add_seconds(60, () => {
             foreach (ConversationSelectorRow row in rows.values) row.update();
             return true;
@@ -29,22 +32,31 @@ public class ConversationSelector : ListBox {
         foreach (Conversation conversation in stream_interactor.get_module(ConversationManager.IDENTITY).get_active_conversations()) {
             add_conversation(conversation);
         }
+
+        foreach (Account acc in stream_interactor.get_accounts()) {
+            add_account(acc);
+            stdout.printf("Added account : %s\n", acc.display_name);
+        }
         return this;
     }
 
     construct {
-        this.stream_interactor = stream_interactor;
-
         get_style_context().add_class("sidebar");
         set_filter_func(filter);
         set_header_func(header);
         set_sort_func(sort);
 
         realize.connect(() => {
-            ListBoxRow? first_row = get_row_at_index(0);
-            if (first_row != null) {
-                select_row(first_row);
-                row_activated(first_row);
+            int i = 0;
+            ListBoxRow? list_row = get_row_at_index(i++);
+            while (list_row != null) {
+                ConversationSelectorRow? first_row = list_row as ConversationSelectorRow;
+                if (first_row != null) {
+                    select_row(first_row);
+                    row_activated(first_row);
+                    return;
+                }
+                list_row = get_row_at_index(i++);
             }
         });
     }
@@ -89,6 +101,17 @@ public class ConversationSelector : ListBox {
         invalidate_sort();
     }
 
+    private void add_account(Account account) {
+        ConversationSelectorAccountSep sep;
+        if (!seps.has_key(account)) {
+            sep = new ConversationSelectorAccountSep(stream_interactor, account);
+            seps[account] = sep;
+            add(sep);
+            sep.main_revealer.set_reveal_child(true);
+        }
+        invalidate_sort(); // FIXME check that this works with accounts
+    }
+
     private void select_fallback_conversation(Conversation conversation) {
         if (get_selected_row() == rows[conversation]) {
             int index = rows[conversation].get_index();
@@ -108,6 +131,13 @@ public class ConversationSelector : ListBox {
         if (rows.has_key(conversation) && !conversation.active) {
             remove(rows[conversation]);
             rows.unset(conversation);
+        }
+    }
+
+    private void remove_account(Account account) {
+        if (seps.has_key(account)) {
+            remove(seps[account]);
+            seps.unset(account);
         }
     }
 
@@ -141,24 +171,42 @@ public class ConversationSelector : ListBox {
                 }
             }
         }
+        // ConversationSelectorAccountSep? sep = r as ConversationSelectorAccountSep;
+        // if (sep != null) {
+        //     return false;
+        // }
         return true;
     }
 
     private int sort(ListBoxRow row1, ListBoxRow row2) {
         ConversationSelectorRow cr1 = row1 as ConversationSelectorRow;
         ConversationSelectorRow cr2 = row2 as ConversationSelectorRow;
+        ConversationSelectorAccountSep s1 = row1 as ConversationSelectorAccountSep;
+        ConversationSelectorAccountSep s2 = row2 as ConversationSelectorAccountSep;
         if (cr1 != null && cr2 != null) {
             Conversation c1 = cr1.conversation;
             Conversation c2 = cr2.conversation;
+            int comp = c1.account.display_name.collate(c2.account.display_name);
+            if (comp != 0) return comp;
             if (c1.last_active == null) return -1;
             if (c2.last_active == null) return 1;
-            int comp = c2.last_active.compare(c1.last_active);
+            comp = c2.last_active.compare(c1.last_active);
             if (comp == 0) {
                 return Util.get_conversation_display_name(stream_interactor, c1)
                     .collate(Util.get_conversation_display_name(stream_interactor, c2));
             } else {
                 return comp;
             }
+        } else if (s1 != null && s2 != null) {
+            return s1.account.display_name.collate(s2.account.display_name);
+        } else if (s1 != null && cr2 != null) {
+            int comp = s1.account.display_name.collate(cr2.conversation.account.display_name);
+            if (comp == 0) return -1;
+            return comp;
+        } else if (cr1 != null && s2 != null) {
+            int comp = cr1.conversation.account.display_name.collate(s2.account.display_name);
+            if (comp == 0) return 1;
+            return comp;
         }
         return 0;
     }

--- a/main/src/ui/conversation_selector/conversation_selector_account_sep.vala
+++ b/main/src/ui/conversation_selector/conversation_selector_account_sep.vala
@@ -1,0 +1,49 @@
+using Gee;
+using Gdk;
+using Gtk;
+using Pango;
+
+using Dino;
+using Dino.Entities;
+using Xmpp;
+
+namespace Dino.Ui {
+
+[GtkTemplate (ui = "/im/dino/Dino/conversation_selector/conversation_account_separator.ui")]
+public class ConversationSelectorAccountSep : ListBoxRow {
+
+    public signal void closed();
+
+    [GtkChild] protected Label name_label;
+    [GtkChild] public Revealer main_revealer;
+
+    public Account account { get; private set; }
+
+    protected ContentItem? last_content_item;
+    protected bool read = true;
+
+
+    protected StreamInteractor stream_interactor;
+
+    construct {
+        name_label.attributes = new AttrList();
+        name_label.attributes.insert(attr_weight_new(Weight.BOLD));
+    }
+
+    public ConversationSelectorAccountSep(StreamInteractor stream_interactor, Account account) {
+        this.account = account;
+        this.stream_interactor = stream_interactor;
+        this.activatable = false;
+        this.focus_on_click = false;
+        this.selectable = false;
+
+        update_name_label();
+    }
+
+    protected void update_name_label() {
+        name_label.label = account.display_name;
+    }
+}
+
+}
+


### PR DESCRIPTION
The conversations in the sidebar are now grouped by their respective
accounts to further clarify which account is used to talk in which
conversation.

Accounts are sorted alphabetically by display_name, and conversations
are then sorted by most recent inside each account.

However, I couldn't manage to connect a signal when the account alias is
modified in order to update the labels on the separators.

Also, I feel like some king of GtkTree* layout might have been more
semantically appropriate here, but would have have required a much
bigger refactoring.