### PR TITLE
Scroll sidebar to follow conversation focus [fixes #544]

### DIFF
--- a/main/src/ui/unified_window.vala
+++ b/main/src/ui/unified_window.vala
@@ -86,7 +86,7 @@ public class UnifiedWindow : Gtk.Window {
             chat_input.text_input.grab_focus();
             return true;
         });
-        conversation_selector = ((ConversationSelector) builder.get_object("conversation_list")).init(stream_interactor);
+        conversation_selector = ((ConversationSelector) builder.get_object("conversation_list")).init(stream_interactor, this);
         goto_end_revealer = (Revealer) builder.get_object("goto_end_revealer");
         goto_end_button = (Button) builder.get_object("goto_end_button");
         search_box = ((GlobalSearch) builder.get_object("search_box")).init(stream_interactor);


### PR DESCRIPTION
When cycling through the conversations using the keyboard shortcut, the
GtkScrolledWindow now scrolls appropriately to display the active
conversation.

This was implemented using inspiration from
https://stackoverflow.com/questions/6903170/auto-scroll-a-gtkscrolledwindow
, I would welcome any solution that uses a more idomatic method, this
feels quite hacky to me. But at least it works :)