### PR TITLE
Consistent "Could not", instead of "failed"

### DIFF
--- a/main/src/ui/conversation_summary/file_widget.vala
+++ b/main/src/ui/conversation_summary/file_widget.vala
@@ -269,7 +269,7 @@ public class FileWidget : Box {
                 image_stack.set_visible_child_name("content_type_image");
                 break;
             case FileTransfer.State.FAILED:
-                mime_label.label = "<span size='small' foreground=\"#f44336\">" + _("File transfer failed") + "</span>";
+                mime_label.label = "<span size='small' foreground=\"#f44336\">" + _("Could not transfer file") + "</span>";
                 image_stack.set_visible_child_name("content_type_image");
                 break;
         }

--- a/main/src/ui/notifications.vala
+++ b/main/src/ui/notifications.vala
@@ -106,7 +106,7 @@ public class Notifications : Object {
     }
 
     private void notify_connection_error(Account account, ConnectionManager.ConnectionError error) {
-        Notification notification = new Notification(_("Failed connecting to %s").printf(account.bare_jid.domainpart));
+        Notification notification = new Notification(_("Could not connect to %s").printf(account.bare_jid.domainpart));
         switch (error.source) {
             case ConnectionManager.ConnectionError.Source.SASL:
                 notification.set_body("Wrong password");


### PR DESCRIPTION
"Could not connect to %s"
https://github.com/dino/dino/blob/master/main/src/ui/manage_accounts/add_account_dialog.vala#L239
"Could not establish a secure connection"
https://github.com/dino/dino/blob/master/main/data/manage_accounts/add_account_dialog.ui#L153