### PR TITLE
Do not mark abstract class contstuctors public

### DIFF
--- a/libdino/src/service/content_item_store.vala
+++ b/libdino/src/service/content_item_store.vala
@@ -207,7 +207,7 @@ public abstract class ContentItem : Object {
     public Encryption? encryption { get; set; default=null; }
     public Entities.Message.Marked? mark { get; set; default=null; }
 
-    public ContentItem(int id, string ty, Jid jid, DateTime sort_time, DateTime display_time, Encryption encryption, Entities.Message.Marked mark) {
+    ContentItem(int id, string ty, Jid jid, DateTime sort_time, DateTime display_time, Encryption encryption, Entities.Message.Marked mark) {
         this.id = id;
         this.type_ = ty;
         this.jid = jid;

--- a/qlite/src/column.vala
+++ b/qlite/src/column.vala
@@ -55,7 +55,7 @@ public abstract class Column<T> {
         return res;
     }
 
-    public Column(string name, int type) {
+    Column(string name, int type) {
         this.name = name;
         this.sqlite_type = type;
     }

--- a/qlite/src/statement_builder.vala
+++ b/qlite/src/statement_builder.vala
@@ -15,7 +15,7 @@ public abstract class StatementBuilder {
         public T value;
         public Column<T>? column;
 
-        public AbstractField(T value) {
+        AbstractField(T value) {
             this.value = value;
         }
 


### PR DESCRIPTION
Starting with Vala 0.45.1, it is an error to mark abstract class
constructors public[0,1]. This commit removes three such
declarations.

fixes #609

[0] https://gitlab.gnome.org/GNOME/vala/raw/master/NEWS
[1] https://gitlab.gnome.org/GNOME/vala/issues/766

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>