### PR TITLE
Syle quotes, fenced code blocks, and strikethrough text (XEP-0393)

### DIFF
--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -223,8 +223,8 @@ public static string parse_add_markup(string s_, string? highlight_word, bool pa
             assert_not_reached();
         }
 
-        string[] markup_string = new string[]{"`", "_", "*"};
-        string[] convenience_tag = new string[]{"tt", "i", "b"};
+        string[] markup_string = new string[]{"`", "_", "*", "~"};
+        string[] convenience_tag = new string[]{"tt", "i", "b", "s"};
 
         for (int i = 0; i < markup_string.length; i++) {
             string markup_esc = Regex.escape_string(markup_string[i]);

--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -225,6 +225,27 @@ public static string parse_add_markup(string s_, string? highlight_word, bool pa
                 assert_not_reached();
             }
         }
+
+        // Quotes are handled differently, since `>` is not matched
+        try {
+            // Match a whole line only
+            Regex regex = new Regex("(?:^|\n)(&gt; ?)(.+(?:$|\n))");
+            MatchInfo match_info;
+            regex.match(s.down().strip(), 0, out match_info);
+            if (match_info.matches()) {
+                int markup_start, markup_end, qoute_start, quote_end;
+                match_info.fetch_pos(1, out markup_start, out markup_end);
+                match_info.fetch_pos(2, out qoute_start, out quote_end);
+                return parse_add_markup(s[0:markup_start], highlight_word, parse_links, parse_text_markup, already_escaped) +
+                    "<span weight=\"light\" style=\"italic\">" +
+                    "  " + s[markup_start:markup_end] +
+                    parse_add_markup(s[qoute_start:quote_end], highlight_word, parse_links, parse_text_markup, already_escaped) +
+                    "</span>" +
+                    parse_add_markup(s[quote_end:s.length], highlight_word, parse_links, parse_text_markup, already_escaped);
+            }
+        } catch (RegexError e) {
+            assert_not_reached();
+        }
     }
 
     return s;

--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -205,6 +205,24 @@ public static string parse_add_markup(string s_, string? highlight_word, bool pa
     }
 
     if (parse_text_markup) {
+        // Try to match preformatted code blocks first
+        try {
+            Regex regex = new Regex("(?:^|\n)(```(?:(?!\n\n|```)(?:.|\n))+(?:$|```|\n\n))");
+            MatchInfo match_info;
+            regex.match(s.down().strip(), 0, out match_info);
+            if (match_info.matches()) {
+                int start, end;
+                match_info.fetch_pos(1, out start, out end);
+                return parse_add_markup(s[0:start], highlight_word, parse_links, parse_text_markup, already_escaped) +
+                    "<tt>" +
+                    s[start:end] +
+                    "</tt>" +
+                    parse_add_markup(s[end:s.length], highlight_word, parse_links, parse_text_markup, already_escaped);
+            }
+        } catch (RegexError e) {
+            assert_not_reached();
+        }
+
         string[] markup_string = new string[]{"`", "_", "*"};
         string[] convenience_tag = new string[]{"tt", "i", "b"};
 


### PR DESCRIPTION
Style quotes (lines beginning with `>`) by padding them with two spaces and putting the line in a thinner, italics font.

![DeepinScreenshot_select-area_20191007162711](https://user-images.githubusercontent.com/969721/66322051-d3e98580-e921-11e9-8913-1007a360e28c.png)

Should work with quotes regardless of their position in a message, as long as the `>` character starts the line. Simple line breaks will end quoted markup. This does not conform the [markdown](https://daringfireball.net/projects/markdown/syntax#blockquote) standard but [XEP-0393](https://xmpp.org/extensions/xep-0393.html#quote) says nothing about it so I took the liberty to do it this way. Technical reason for it is that parsing with regexes has limitations, and I couldn't find a simple one which would cover this case while not breaking all the others.

Any feedback is appreciated!