### PR TITLE
Add an option to enable OMEMO by default in new conversations

### DIFF
--- a/libdino/src/entity/settings.vala
+++ b/libdino/src/entity/settings.vala
@@ -11,6 +11,7 @@ public class Settings : Object {
         send_marker_ = col_to_bool_or_default("send_marker", true);
         notifications_ = col_to_bool_or_default("notifications", true);
         convert_utf8_smileys_ = col_to_bool_or_default("convert_utf8_smileys", true);
+        omemo_default_ = col_to_bool_or_default("omemo_default", false);
     }
 
     private bool col_to_bool_or_default(string key, bool def) {
@@ -63,6 +64,18 @@ public class Settings : Object {
                     .value(db.settings.value, value.to_string())
                     .perform();
             convert_utf8_smileys_ = value;
+        }
+    }
+
+    private bool omemo_default_;
+    public bool omemo_default {
+        get { return omemo_default_; }
+        set {
+            db.settings.upsert()
+                    .value(db.settings.key, "omemo_default", true)
+                    .value(db.settings.value, value.to_string())
+                    .perform();
+            omemo_default_ = value;
         }
     }
 }

--- a/libdino/src/service/conversation_manager.vala
+++ b/libdino/src/service/conversation_manager.vala
@@ -8,6 +8,8 @@ public class ConversationManager : StreamInteractionModule, Object {
     public static ModuleIdentity<ConversationManager> IDENTITY = new ModuleIdentity<ConversationManager>("conversation_manager");
     public string id { get { return IDENTITY.id; } }
 
+    private Dino.Entities.Settings settings = Dino.Application.get_default().settings;
+
     public signal void conversation_activated(Conversation conversation);
     public signal void conversation_deactivated(Conversation conversation);
 
@@ -46,6 +48,9 @@ public class ConversationManager : StreamInteractionModule, Object {
 
         // Create a new converation
         Conversation conversation = new Conversation(jid, account, type);
+        if (settings.omemo_default) {
+            conversation.encryption = Encryption.OMEMO;
+        }
         add_conversation(conversation);
         conversation.persist(db);
         return conversation;

--- a/main/data/settings_dialog.ui
+++ b/main/data/settings_dialog.ui
@@ -65,6 +65,18 @@
                                 <property name="height">1</property>
                             </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="omemo_default_checkbutton">
+                            <property name="label" translatable="yes">Enable OMEMO by default</property>
+                            <property name="visible">True</property>
+                          </object>
+                          <packing>
+                              <property name="left_attach">0</property>
+                              <property name="top_attach">4</property>
+                              <property name="width">1</property>
+                              <property name="height">1</property>
+                          </packing>
+                        </child>
                     </object>
                 </child>
             </object>

--- a/main/src/ui/settings_dialog.vala
+++ b/main/src/ui/settings_dialog.vala
@@ -9,6 +9,7 @@ class SettingsDialog : Dialog {
     [GtkChild] private CheckButton marker_checkbutton;
     [GtkChild] private CheckButton notification_checkbutton;
     [GtkChild] private CheckButton emoji_checkbutton;
+    [GtkChild] private CheckButton omemo_default_checkbutton;
 
     Dino.Entities.Settings settings = Dino.Application.get_default().settings;
 
@@ -19,11 +20,13 @@ class SettingsDialog : Dialog {
         marker_checkbutton.active = settings.send_marker;
         notification_checkbutton.active = settings.notifications;
         emoji_checkbutton.active = settings.convert_utf8_smileys;
+        omemo_default_checkbutton.active = settings.omemo_default;
 
         typing_checkbutton.toggled.connect(() => { settings.send_typing = typing_checkbutton.active; } );
         marker_checkbutton.toggled.connect(() => { settings.send_marker = marker_checkbutton.active; } );
         notification_checkbutton.toggled.connect(() => { settings.notifications = notification_checkbutton.active; } );
         emoji_checkbutton.toggled.connect(() => { settings.convert_utf8_smileys = emoji_checkbutton.active; });
+        omemo_default_checkbutton.toggled.connect(() => { settings.omemo_default = omemo_default_checkbutton.active; });
     }
 }
 


### PR DESCRIPTION
This adds a checkbox to the settings dialog with the label "Enable OMEMO by default", which, when checked, will cause new conversations to start out with OMEMO encryption.