### PR TITLE
Fix reporting failed HTTP upload

### DIFF
--- a/plugins/http-files/src/file_sender.vala
+++ b/plugins/http-files/src/file_sender.vala
@@ -102,7 +102,7 @@ public class HttpFileSender : FileSender, Object {
         Soup.Session session = new Soup.Session();
         try {
             yield session.send_async(message);
-            if (message.status_code < 200 && message.status_code >= 300) {
+            if (message.status_code < 200 || message.status_code >= 300) {
                 throw new FileSendError.UPLOAD_FAILED("HTTP status code %s".printf(message.status_code.to_string()));
             }
         } catch (Error e) {


### PR DESCRIPTION
Status code can't be less than 200 and greater than or equal 300 at the same time. Using || instead of && marks all uploads that do not have 2xx status code as "failed".