### PR TITLE
Remove background transparency of text field

### DIFF
--- a/main/data/theme.css
+++ b/main/data/theme.css
@@ -110,6 +110,11 @@ window.dino-main button.dino-chatinput-button:checked:backdrop {
 }
 
 
+.dino-chatinput textview, .dino-chatinput textview text {
+    background-color: @theme_base_color;
+}
+
+
 /*Chat input warning*/
 
 box.dino-input-warning frame border {
@@ -124,6 +129,7 @@ box.dino-input-warning frame separator {
 box.dino-input-warning label {
     color: mix(@warning_color, @theme_fg_color, 0.5);
 }
+
 
 /*Chat input error*/
 

--- a/main/data/theme.css
+++ b/main/data/theme.css
@@ -110,10 +110,6 @@ window.dino-main button.dino-chatinput-button:checked:backdrop {
 }
 
 
-.dino-chatinput textview, .dino-chatinput textview text {
-    background-color: transparent;
-}
-
 /*Chat input warning*/
 
 box.dino-input-warning frame border {


### PR DESCRIPTION
Fixes #653.

I couldn't think of a good reason why the background should be transparent, so I removed this CSS instruction and the text is now rendered correctly on my system.