### PR TITLE
Fix starting private conversations with MUC members

### DIFF
--- a/main/src/ui/occupant_menu/view.vala
+++ b/main/src/ui/occupant_menu/view.vala
@@ -15,6 +15,8 @@ public class View : Popover {
     private ListBox invite_list;
     private Box? jid_menu = null;
 
+    private Jid? selected_jid;
+
     public View(StreamInteractor stream_interactor, Conversation conversation) {
         this.stream_interactor = stream_interactor;
         this.conversation = conversation;
@@ -66,6 +68,7 @@ public class View : Popover {
     }
 
     private void show_menu(Jid jid, string name_) {
+        selected_jid = jid;
         stack.transition_type = StackTransitionType.SLIDE_LEFT;
 
         string name = name_;
@@ -102,10 +105,9 @@ public class View : Popover {
     }
 
     private void private_conversation_button_clicked() {
-        ListRow? list_row = list.list_box.get_selected_row() as ListRow;
-        if (list_row == null) return;
+        if (selected_jid == null) return;
 
-        Conversation conversation = stream_interactor.get_module(ConversationManager.IDENTITY).create_conversation(list_row.jid, list_row.conversation.account, Conversation.Type.GROUPCHAT_PM);
+        Conversation conversation = stream_interactor.get_module(ConversationManager.IDENTITY).create_conversation(selected_jid, conversation.account, Conversation.Type.GROUPCHAT_PM);
         stream_interactor.get_module(ConversationManager.IDENTITY).start_conversation(conversation);
 
         Application app = GLib.Application.get_default() as Application;
@@ -113,10 +115,9 @@ public class View : Popover {
     }
 
     private void kick_button_clicked() {
-        ListRow? list_row = list.list_box.get_selected_row() as ListRow;
-        if (list_row == null) return;
+        if (selected_jid == null) return;
 
-        stream_interactor.get_module(MucManager.IDENTITY).kick(conversation.account, conversation.counterpart, list_row.jid.resourcepart);
+        stream_interactor.get_module(MucManager.IDENTITY).kick(conversation.account, conversation.counterpart, selected_jid.resourcepart);
     }
 }
 


### PR DESCRIPTION
At least for some users (?), the existing codepath was broken (the list
row would come back null and we'd bail out silently). All we actually
need is the JID, so it's easy enough to store this ourselves, fixing the
bug.

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>