### PR TITLE
Add inline audio widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 before_install:
   - export USE_CCACHE=1
   - sudo apt-get update
-  - sudo apt-get install -y cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev
+  - sudo apt-get install -y cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev libgstreamer1.0-dev gstreamer1.0-plugins-good
 install:
   - ./configure --with-tests $CONFIGURE_FLAGS
   - make

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -12,6 +12,10 @@ find_packages(MAIN_PACKAGES REQUIRED
     ICU
 )
 
+set(MAIN_PACKAGES ${MAIN_PACKAGES} gstreamer-1.0)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GST REQUIRED IMPORTED_TARGET gstreamer-1.0)
+
 set(RESOURCE_LIST
     icons/dino-changes-prevent-symbolic.svg
     icons/dino-conversation-list-placeholder-arrow.svg
@@ -48,6 +52,7 @@ set(RESOURCE_LIST
     conversation_selector/chat_row_tooltip.ui
     conversation_selector/conversation_row.ui
     conversation_summary/image_toolbar.ui
+    conversation_summary/multimedia_toolbar.ui
     conversation_summary/item_metadata_header.ui
     conversation_summary/view.ui
     manage_accounts/account_row.ui
@@ -173,7 +178,7 @@ add_definitions(${VALA_CFLAGS} -DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\" -DLOCALE
 add_executable(dino ${MAIN_VALA_C} ${MAIN_GRESOURCES_TARGET} src/emojichooser.c)
 add_dependencies(dino ${GETTEXT_PACKAGE}-translations)
 target_include_directories(dino PRIVATE src)
-target_link_libraries(dino libdino ${MAIN_PACKAGES})
+target_link_libraries(dino libdino ${MAIN_PACKAGES} PkgConfig::GST)
 
 if(WIN32)
     target_link_libraries(dino -mwindows)

--- a/main/data/conversation_summary/multimedia_toolbar.ui
+++ b/main/data/conversation_summary/multimedia_toolbar.ui
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+    <object class="GtkBox" id="main">
+        <property name="valign">end</property>
+        <property name="halign">fill</property>
+        <property name="margin">10</property>
+        <property name="visible">True</property>
+        <child>
+            <object class="GtkToolItem">
+                <property name="visible">True</property>
+                <child>
+                    <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <child>
+                            <object class="GtkButton" id="pause_button">
+                                <property name="relief">none</property>
+                                <property name="visible">True</property>
+                                <child>
+                                    <object class="GtkImage" id="pause_image">
+                                        <property name="icon-name">media-playback-start-symbolic</property>
+                                        <property name="icon-size">1</property>
+                                        <property name="visible">True</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkScale" id="seek_scale">
+                                <property name="visible">True</property>
+                                <property name="hexpand">True</property>
+                                <property name="halign">fill</property>
+                                <property name="value-pos">GTK_POS_RIGHT</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+            </object>
+        </child>
+    </object>
+</interface>

--- a/main/src/main.vala
+++ b/main/src/main.vala
@@ -15,6 +15,7 @@ void main(string[] args) {
         internationalize(GETTEXT_PACKAGE, search_path_generator.get_locale_path(GETTEXT_PACKAGE, LOCALE_INSTALL_DIR));
 
         Gtk.init(ref args);
+        Gst.init(ref args);
         Dino.Ui.Application app = new Dino.Ui.Application() { search_path_generator=search_path_generator };
         Plugins.Loader loader = new Plugins.Loader(app);
         loader.loadAll();


### PR DESCRIPTION
In addition to viewing inline images, we can support inline audio (like
Conversations' voice messages) via gstreamer. The code is generic enough
to additionally support inline video via GstGtkSink in the future, but
for now the widget is audio-only to ease review.

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>