### PR TITLE
Consistent nick

### DIFF
--- a/main/data/manage_accounts/dialog.ui
+++ b/main/data/manage_accounts/dialog.ui
@@ -197,7 +197,7 @@
                                                 </child>
                                                 <child>
                                                     <object class="GtkLabel">
-                                                        <property name="label" translatable="yes">Local alias</property>
+                                                        <property name="label" translatable="yes">Nick</property>
                                                         <property name="xalign">1</property>
                                                         <property name="visible">True</property>
                                                         <style>


### PR DESCRIPTION
...as used for the user, I guess, but... it's `nick` [here](https://github.com/dino/dino/blob/master/main/data/add_conversation/conference_details_fragment.ui#L123) and [there](https://github.com/dino/dino/blob/master/main/data/add_conversation/add_groupchat_dialog.ui#L120) for group chat actions, yet on account screen it's `local alias` instead, and I do understand the difference _(In 1:1 only you see your ~~nick~~local alias but your contact sees you as they have you in their roster, unless vcards, blahblah)_ yet you might agree this tech burden should not be reflected in the UI.

Also, the word `alias` is used in the same group chat actions dialogues too but now suddenly it means something else, it's not about you but about the channel.
