### PR TITLE
[UI] Fix menu button alignment

### DIFF
--- a/main/data/conversation_list_titlebar_csd.ui
+++ b/main/data/conversation_list_titlebar_csd.ui
@@ -25,7 +25,6 @@
         </child>
         <child>
             <object class="GtkMenuButton" id="menu_button">
-                <property name="valign">center</property>
                 <property name="visible">True</property>
                 <child>
                     <object class="GtkImage">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7175914/75992853-e380f080-5ef8-11ea-865b-50c67c810786.png)

After:
![image](https://user-images.githubusercontent.com/7175914/75992979-1a570680-5ef9-11ea-8d93-b1a7587011c1.png)

(the left hamburger menu button now is of the same height as all the other buttons)