### PR TITLE
quietly remove whitespace when entering a new jid; is forbidden anyway & decreases user experience

### DIFF
--- a/main/src/ui/add_conversation/add_contact_dialog.vala
+++ b/main/src/ui/add_conversation/add_contact_dialog.vala
@@ -51,6 +51,7 @@ protected class AddContactDialog : Gtk.Dialog {
 
     private void on_jid_entry_changed() {
         try {
+            jid_entry.text = jid_entry.text.strip();
             Jid parsed_jid = new Jid(jid_entry.text);
             ok_button. sensitive = parsed_jid != null && parsed_jid.resourcepart == null &&
                     stream_interactor.get_module(RosterManager.IDENTITY).get_roster_item(account, parsed_jid) == null;

--- a/main/src/ui/add_conversation/add_groupchat_dialog.vala
+++ b/main/src/ui/add_conversation/add_groupchat_dialog.vala
@@ -50,6 +50,7 @@ protected class AddGroupchatDialog : Gtk.Dialog {
 
     private bool check_ok() {
         try {
+	    jid_entry.text = jid_entry.text.strip();
             Jid parsed_jid = new Jid(jid_entry.text);
             ok_button.sensitive = parsed_jid != null && parsed_jid.localpart != null && parsed_jid.resourcepart == null;
         } catch (InvalidJidError e) {


### PR DESCRIPTION
whitespace is anyways prohibited inside the jid and when one enters a space accidentally, it can be hard to see what is wrong (why the add button is greyed out).

-> removing it while the user is entering the JID is a elegant solution for that.