### PR TITLE
Add alternative character sequence for kiss emoji

### DIFF
--- a/main/src/ui/chat_input/smiley_converter.vala
+++ b/main/src/ui/chat_input/smiley_converter.vala
@@ -26,6 +26,7 @@ class SmileyConverter {
         smiley_translations[":'("] = "😢";
         smiley_translations[":/"] = "😕";
         smiley_translations["<3"] = "❤️";
+        smiley_translations[":*"] = "😘️";
         smiley_translations[":-*"] = "😘️";
     }
 


### PR DESCRIPTION
As discussed in the channel, `:*` is consistent with the other sequences without a hyphen "nose" and is quicker to type