### PR TITLE
Add keyboard shortcut to open the emoji picker

### DIFF
--- a/main/data/shortcuts.ui
+++ b/main/data/shortcuts.ui
@@ -46,6 +46,19 @@
                         </child>
                     </object>
                 </child>
+                <child>
+                    <object class="GtkShortcutsGroup">
+                        <property name="visible">True</property>
+                        <property name="title" translatable="yes">Input</property>
+                        <child>
+                            <object class="GtkShortcutsShortcut">
+                                <property name="visible">True</property>
+                                <property name="accelerator">&lt;ctrl&gt;E</property>
+                                <property name="title" translatable="yes">Open emoji picker</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
             </object>
         </child>
     </object>

--- a/main/src/ui/application.vala
+++ b/main/src/ui/application.vala
@@ -148,6 +148,11 @@ public class Dino.Ui.Application : Gtk.Application, Dino.Application {
         add_action(loop_conversations_bw_action);
         set_accels_for_action("app.loop_conversations_bw", new string[]{"<Ctrl><Shift>Tab"});
 
+        SimpleAction open_emoji_picker_action = new SimpleAction("open_emoji_picker", null);
+        open_emoji_picker_action.activate.connect(() => { controller.open_emoji_picker(); });
+        add_action(open_emoji_picker_action);
+        set_accels_for_action("app.open_emoji_picker", new string[]{"<Ctrl>E"});
+
         SimpleAction open_shortcuts_action = new SimpleAction("open_shortcuts", null);
         open_shortcuts_action.activate.connect((variant) => {
             Builder builder = new Builder.from_resource("/im/dino/Dino/shortcuts.ui");

--- a/main/src/ui/chat_input/chat_input_controller.vala
+++ b/main/src/ui/chat_input/chat_input_controller.vala
@@ -158,6 +158,10 @@ public class ChatInputController : Object {
         }
         return false;
     }
+
+    public void open_emoji_picker() {
+        chat_input.open_emoji_picker();
+    }
 }
 
 }

--- a/main/src/ui/chat_input/view.vala
+++ b/main/src/ui/chat_input/view.vala
@@ -27,6 +27,7 @@ public class View : Box {
     [GtkChild] public Label chat_input_status;
 
     public EncryptionButton encryption_widget;
+    public MenuButton emoji_button;
 
     public View init(StreamInteractor stream_interactor) {
         this.stream_interactor = stream_interactor;
@@ -47,7 +48,7 @@ public class View : Box {
 
         // Emoji button for emoji picker (recents don't work < 3.22.19, category icons don't work <3.23.2)
         if (Gtk.get_major_version() >= 3 && Gtk.get_minor_version() >= 24) {
-            MenuButton emoji_button = new MenuButton() { relief=ReliefStyle.NONE, margin_top=3, valign=Align.START, visible=true };
+            emoji_button = new MenuButton() { relief=ReliefStyle.NONE, margin_top=3, valign=Align.START, visible=true };
             emoji_button.get_style_context().add_class("flat");
             emoji_button.get_style_context().add_class("dino-chatinput-button");
             emoji_button.image = new Image.from_icon_name("dino-emoticon-symbolic", IconSize.BUTTON) { visible=true };
@@ -115,6 +116,12 @@ public class View : Box {
             chat_input_status.get_style_context().remove_class("input-status-highlight-once");
             return false;
         });
+    }
+
+    public void open_emoji_picker() {
+        Popover chooser = emoji_button.get_popover();
+        if (chooser != null)
+            chooser.popup();
     }
 }
 

--- a/main/src/ui/conversation_view_controller.vala
+++ b/main/src/ui/conversation_view_controller.vala
@@ -169,5 +169,9 @@ public class ConversationViewController : Object {
         }
         return false;
     }
+
+    public void open_emoji_picker() {
+        chat_input_controller.open_emoji_picker();
+    }
 }
 }

--- a/main/src/ui/main_window_controller.vala
+++ b/main/src/ui/main_window_controller.vala
@@ -158,6 +158,10 @@ public class MainWindowController : Object {
         conversation_view_controller.search_menu_entry.search_button.active = false;
         window.search_revealer.reveal_child = false;
     }
+
+    public void open_emoji_picker() {
+        conversation_view_controller.open_emoji_picker();
+    }
 }
 
 }


### PR DESCRIPTION
Having to go search for the tiny button at the bottom right of my screen everytime I wanted to send an emoji was getting annoying fast.

This is a minor change to the code, but I think it's a significant quality of life upgrade.

For now, I chose Ctrl-E (as in emoji) as the shortcut, but I'm open to other ideas. For example, I know a few programs that use Ctrl-Shift-U (as in unicode).