### PR TITLE
Adding spaces in beginning and ending of text

### DIFF
--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -377,7 +377,7 @@ public static string parse_add_markup(string s_, string? highlight_word, bool pa
                     int start, end;
                     match_info.fetch_pos(2, out start, out end);
                     return parse_add_markup(s[0:start-1], highlight_word, parse_links, parse_text_markup, already_escaped) +
-                        s[start-1:start] + @"<$(convenience_tag[i])>" + s[start:end] + @"</$(convenience_tag[i])>" + s[end:end+1] +
+                        s[start-1:start] + " " + @"<$(convenience_tag[i])>" + s[start:end] + @"</$(convenience_tag[i])>" + " " + s[end:end+1] +
                         parse_add_markup(s[end+1:s.length], highlight_word, parse_links, parse_text_markup, already_escaped);
                 }
             } catch (RegexError e) {


### PR DESCRIPTION
This pr is in regarding resolving the issue [https://github.com/dino/dino/issues/704](https://github.com/dino/dino/issues/704 ), The purpose of the pr is to distinguish the important part of bold text from it's unimportant (*) signs. So by appending spaces before and after the text, we can resolve the above the problem.