### PR TITLE
Add emoji picker shortcut to ShortcutWindow

### DIFF
--- a/main/data/shortcuts.ui
+++ b/main/data/shortcuts.ui
@@ -46,6 +46,19 @@
                         </child>
                     </object>
                 </child>
+                <child>
+                    <object class="GtkShortcutsGroup">
+                        <property name="visible">True</property>
+                        <property name="title" translatable="yes">Text input</property>
+                        <child>
+                            <object class="GtkShortcutsShortcut">
+                                <property name="visible">True</property>
+                                <property name="accelerator">&lt;ctrl&gt;semicolon &lt;ctrl&gt;period</property>
+                                <property name="title" translatable="yes">Open emoji picker</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
             </object>
         </child>
     </object>


### PR DESCRIPTION
While I understand that the <Ctrl+.>/<Ctrl+;> shortcut isn't a dino shortcut but a default GTK one, I feel that discoverability is bad enough in this case that it warrants adding to dino's shortcut window.

* First that shortcut doesn't have the ubiquity of something like <Ctrl+C> or <Ctrl+V>. I personaly just discovered that it is the shortcut used by Windows 10's emoji picker;
* moreover, even after extensive searching I wasn't able to locate any user friendly documentation on this shortcut. Here are the only mentions I found:
  * https://github.com/dino/dino/pull/801#issuecomment-610784352
  * https://developer.gnome.org/gtk3/stable/GtkEntry.html#GtkEntry-insert-emoji

I think user would benefit having this reminder added to dino.

That said, I know that those shortcuts could be changed by system-wide settings, so I would be interested in some pointers on how to retrieve the actual shortcut in Vala in order to improve this pull request