### PR TITLE
Fix #795: Hovering highlights wrong message

### DIFF
--- a/main/src/ui/conversation_content_view/conversation_view.vala
+++ b/main/src/ui/conversation_content_view/conversation_view.vala
@@ -128,11 +128,12 @@ public class ConversationView : Box, Plugins.ConversationItemCollection, Plugins
 
         last_y_root = y_root;
 
-        // Get pointer location in main
-        int geometry_x, geometry_y, geometry_width, geometry_height, dest_x, dest_y;
+        int toplevel_window_pos_x, toplevel_window_pos_y, dest_x, dest_y;
         Widget toplevel_widget = this.get_toplevel();
-        toplevel_widget.get_window().get_geometry(out geometry_x, out geometry_y, out geometry_width, out geometry_height);
-        toplevel_widget.translate_coordinates(main, x_root - geometry_x, y_root - geometry_y, out dest_x, out dest_y);
+        // Obtain the position of the main application window relative to the root window
+        toplevel_widget.get_window().get_origin(out toplevel_window_pos_x, out toplevel_window_pos_y);
+        // Get the pointer location relative to the `main` box
+        toplevel_widget.translate_coordinates(main, x_root - toplevel_window_pos_x, y_root - toplevel_window_pos_y, out dest_x, out dest_y);
 
         // Get widget under pointer
         int h = 0;

--- a/main/src/ui/conversation_content_view/conversation_view.vala
+++ b/main/src/ui/conversation_content_view/conversation_view.vala
@@ -102,7 +102,10 @@ public class ConversationView : Box, Plugins.ConversationItemCollection, Plugins
 
     private bool on_leave_notify_event(Gdk.EventCrossing event) {
         mouse_inside = false;
-        if (currently_highlighted != null) currently_highlighted.unset_state_flags(StateFlags.PRELIGHT);
+        if (currently_highlighted != null) {
+            currently_highlighted.unset_state_flags(StateFlags.PRELIGHT);
+            currently_highlighted = null;
+        }
         message_menu_box.visible = false;
         return false;
     }
@@ -114,7 +117,7 @@ public class ConversationView : Box, Plugins.ConversationItemCollection, Plugins
     }
 
     private void update_highlight(int x_root, int y_root) {
-        if ((last_y_root - y_root).abs() <= 2) {
+        if (currently_highlighted != null && (last_y_root - y_root).abs() <= 2) {
             return;
         }
 


### PR DESCRIPTION
Fixes #795.

See the commit messages for details.

`Improve message highlighting logic` removes the unused `bool mouse_inside`, adds a few clarifying comments and fixes a minor issue: when a pointer is above the bottom margin of `DinoUiSizeRequestBox`, the last conversation item gets highlighted. This is fixed by moving line 137 to line 144.