### PR TITLE
Enable omemo encryption by default in new conversations

### DIFF
--- a/libdino/src/entity/conversation.vala
+++ b/libdino/src/entity/conversation.vala
@@ -32,7 +32,7 @@ public class Conversation : Object {
             }
         }
     }
-    public Encryption encryption { get; set; default = Encryption.NONE; }
+    public Encryption encryption { get; set; default = Encryption.OMEMO; }
     public Message? read_up_to { get; set; }
 
     public enum NotifySetting { DEFAULT, ON, OFF, HIGHLIGHT }


### PR DESCRIPTION
This helps to prevent the unintentional sending of unencrypted messages,
as well as promotes the usage of e2e encryption.

This PR will fix https://github.com/dino/dino/issues/844