### PR TITLE
Add different formating with less contrast for markup strings

### DIFF
--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -381,7 +381,9 @@ public static string parse_add_markup(string s_, string? highlight_word, bool pa
                     int start, end;
                     match_info.fetch_pos(2, out start, out end);
                     return parse_add_markup(s[0:start-1], highlight_word, parse_links, parse_text_markup, already_escaped) +
-                        s[start-1:start] + @"<$(convenience_tag[i])>" + s[start:end] + @"</$(convenience_tag[i])>" + s[end:end+1] +
+                        "<span color='#999'>" +  s[start-1:start] + "</span>" +
+                        @"<$(convenience_tag[i])>" + s[start:end] + @"</$(convenience_tag[i])>" +
+                        "<span color='#999'>" + s[end:end+1] + "</span>" +
                         parse_add_markup(s[end+1:s.length], highlight_word, parse_links, parse_text_markup, already_escaped);
                 }
             } catch (RegexError e) {


### PR DESCRIPTION
Fixes #704
I did not find a global color for unfocused elements. Therefore, I just used `#999999` which looks nice with both the light and the dark theme:
![dark theme](https://user-images.githubusercontent.com/1271243/87762329-42456780-c813-11ea-95ba-57bc0ca3f319.png)
![light theme](https://user-images.githubusercontent.com/1271243/87762354-4e312980-c813-11ea-8d68-254bafa9acca.png)

Probably it would be nicer to use the color codes from the material palette which would be `#9E9E9E` and `#E0E0E0`.
What do you think?
