### PR TITLE
Fix hangs resending old messages

### DIFF
--- a/main/src/ui/conversation_content_view/message_widget.vala
+++ b/main/src/ui/conversation_content_view/message_widget.vala
@@ -193,7 +193,9 @@ public class MessageItemWidget : SizeRequestBin {
 
                 message.bind_property("marked", this, "marked");
                 this.notify["marked"].connect(() => {
-                    update_label();
+                    /* Only update when the state actually changes so we don't recurse infinitely */
+                    if (message.marked != Message.Marked.SENDING && message.marked != Message.Marked.UNSENT)
+                        update_label();
                 });
             } else {
                 int time_diff = (- (int) message.local_time.difference(new DateTime.now_utc()) / 1000);


### PR DESCRIPTION
If Dino was closed while attempting to send a message, and opened (more
than 10 seconds) later, Dino will correctly attempt to resend the
message. However the resending will incorrectly recurse infinitely from
the signal connected in update_label(), despite no actual changes,
causing Dino to hang.

By checking that the status actually changed, we don't go down this code
path more than once, preventing the recursion and fixing the hang. The
message is still resent and status updated as expected.

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>
Fixes: 7309c6f3 ("Visually highlight pending messages, improve resending")

Cc @fiaxh