### PR TITLE
service/database: use WAL mode + safe PRAGMA synchronous setting

### DIFF
--- a/libdino/src/service/database.vala
+++ b/libdino/src/service/database.vala
@@ -293,12 +293,9 @@ public class Database : Qlite.Database {
         mam_catchup = new MamCatchupTable(this);
         settings = new SettingsTable(this);
         init({ account, jid, entity, content_item, message, message_correction, real_jid, file_transfer, conversation, avatar, entity_identity, entity_feature, roster, mam_catchup, settings });
-        try {
-            exec("PRAGMA synchronous=0");
-        } catch (Error e) { }
-        try {
-            exec("PRAGMA secure_delete=1");
-        } catch (Error e) { }
+        exec("PRAGMA journal_mode = WAL");
+        exec("PRAGMA synchronous = NORMAL");
+        exec("PRAGMA secure_delete = ON");
     }
 
     public override void migrate(long oldVersion) {


### PR DESCRIPTION
Setting PRAGMA synchronous = 0 is really unsafe, and leads to database
corruption (which I've personally experienced). This commit uses
SQLite's Write-Ahead Log (WAL) [1] instead, together with synchronous =
NORMAL. According to [1], this trades off performance for durability
(i.e. it's possible that some transactions may not have committed if the
power gets lost), but still guarantees that the database won't corrupt
itself.

Together, these changes should improve reliability whilst either
improving or having no effect on performance.

[1]: https://www.sqlite.org/wal.html