### PR TITLE
Added more public servers

### DIFF
--- a/main/src/ui/manage_accounts/add_account_dialog.vala
+++ b/main/src/ui/manage_accounts/add_account_dialog.vala
@@ -64,10 +64,13 @@ public class AddAccountDialog : Gtk.Dialog {
 
     private static string[] server_list = new string[]{
         "5222.de",
+	"dismail.de",
+	"intux.de",
+	"parloteo.es",
         "jabber.fr",
         "movim.eu",
         "yax.im"
-    };
+};
 
     private StreamInteractor stream_interactor;
     private Database db;


### PR DESCRIPTION
In this commit I've added more public XMPP servers to the account creation dialog:
* dismail.de
* intux.de
* parloteo.es