### PR TITLE
Add logo and screenshots to the DOAP file

### DIFF
--- a/dino.doap.in
+++ b/dino.doap.in
@@ -2,6 +2,7 @@
 <rdf:RDF xmlns="http://usefulinc.com/ns/doap#"
          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:xmpp="https://linkmauve.fr/ns/xmpp-doap#"
+         xmlns:schema="https://schema.org/"
          xmlns:foaf="http://xmlns.com/foaf/0.1/">
   <Project>
 
@@ -21,6 +22,11 @@
     <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-client" />
     <category rdf:resource="http://api.gnome.org/doap-extensions#apps" />
     <license rdf:resource="http://usefulinc.com/doap/licenses/gplv3" />
+
+    <schema:logo rdf:resource="https://dino.im/img/logo.svg" />
+    <schema:screenshot rdf:resource="https://dino.im/img/screenshot1.png" />
+    <schema:screenshot rdf:resource="https://dino.im/img/screenshot3.png" />
+    <schema:screenshot rdf:resource="https://dino.im/img/screenshot2.png" />
 
     <programming-language>Vala</programming-language>
     <os>Linux</os>


### PR DESCRIPTION
Given upstream is quite unresponsive, we are now using the `https://schema.org/` namespace for these properties.