### PR TITLE
Add Appimage support and build workflow; fixes #278

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential gettext cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev libgspell-1-dev
-          
       - name: Prepare AppImage build
         run: |
+          sudo apt-get update
           sudo apt-get install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
@@ -31,10 +26,6 @@ jobs:
     
       - name: Build AppImage
         run: appimage-builder --skip-test
-      #- name: Build Appimage
-      #  uses: AppImageCrafters/build-appimage@master
-      #  with:
-      #    recipe: "./AppImageBuilder.yml"
           
       - name: Save AppImage
         uses: actions/upload-artifact@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           sudo pip3 install appimage-builder
     
       - name: Build AppImage
-        run: appimage-builder
+        run: appimage-builder --skip-test
       #- name: Build Appimage
       #  uses: AppImageCrafters/build-appimage@master
       #  with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,3 +11,33 @@ jobs:
       - run: make
       - run: build/xmpp-vala-test
       - run: build/signal-protocol-vala-test
+
+  Appimage:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gettext cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev libgspell-1-dev
+          
+      - name: Prepare AppImage build
+        run: |
+          sudo apt-get install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace
+          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+          sudo chmod +x /usr/local/bin/appimagetool
+          sudo pip3 install appimage-builder
+    
+      - name: Build AppImage
+        run: appimage-builder
+      #- name: Build Appimage
+      #  uses: AppImageCrafters/build-appimage@master
+      #  with:
+      #    recipe: "./AppImageBuilder.yml"
+          
+      - name: Save AppImage
+        uses: actions/upload-artifact@master
+        with:
+          name: Dino_Appimage
+          path: ./*.AppImage

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ Makefile
 .idea
 .sqlite3
 gschemas.compiled
+
+/appimage-builder-cache
+/AppDir
+.directory
+
+*.AppImage

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,0 +1,75 @@
+version: 1
+script:
+  # Remove any previous build
+  - rm -rf AppDir | true
+  - mkdir AppDir
+  # Build software
+  #- apt update
+  #- apt install -y build-essential gettext cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev libgspell-1-dev
+  - ./configure --with-libsignal-in-tree
+  - make
+  - make DESTDIR="$(pwd)/AppDir" prefix="/usr" install
+  # Prepare icon
+  - mkdir -p AppDir/usr/share/icons/hicolor/scalable/apps/
+  - cp AppDir/usr/local/share/icons/hicolor/scalable/apps/im.dino.Dino.svg AppDir/usr/share/icons/hicolor/scalable/apps/im.dino.Dino.svg
+
+AppDir:
+  path: ./AppDir
+
+  app_info:
+    id: org.dino.dino
+    name: dino
+    icon: im.dino.Dino
+    version: 0.2.0
+    exec: usr/local/bin/dino
+    # Set the application main script path as argument. Use '$@' to forward CLI parameters
+    exec_args: "$@"
+
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+
+    include:
+      - sqlite3
+      - libgee-0.8-2
+      - libsqlite3-0
+      - libnotify4
+      - libgpgme11
+      - libsoup2.4-1
+      - libgcrypt20
+      - libqrencode4
+      - libgspell-1-2      
+    exclude: []
+
+  runtime:
+    env:
+      PATH: '${APPDIR}/usr/local/bin:${PATH}'
+
+  test:
+    fedora:
+      image: appimagecrafters/tests-env:fedora-30
+      command: ./AppRun
+      use_host_x: true
+    debian:
+      image: appimagecrafters/tests-env:debian-stable
+      command: ./AppRun
+      use_host_x: true
+    arch:
+      image: appimagecrafters/tests-env:archlinux-latest
+      command: ./AppRun
+      use_host_x: true
+    centos:
+      image: appimagecrafters/tests-env:centos-7
+      command: ./AppRun
+      use_host_x: true
+    ubuntu:
+      image: appimagecrafters/tests-env:ubuntu-xenial
+      command: ./AppRun
+      use_host_x: true
+
+AppImage:
+  update-information: None
+  sign-key: None
+  arch: x86_64

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -4,8 +4,8 @@ script:
   - rm -rf AppDir | true
   - mkdir AppDir
   # Build software
-  #- apt update
-  #- apt install -y build-essential gettext cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev libgspell-1-dev
+  - sudo apt-get update
+  - sudo apt-get install -y build-essential gettext cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev libgspell-1-dev
   - ./configure --with-libsignal-in-tree
   - make
   - make DESTDIR="$(pwd)/AppDir" prefix="/usr" install
@@ -22,7 +22,7 @@ AppDir:
     icon: im.dino.Dino
     version: 0.2.0
     exec: usr/local/bin/dino
-    # Set the application main script path as argument. Use '$@' to forward CLI parameters
+    # Use '$@' to forward CLI parameters
     exec_args: "$@"
 
   apt:

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -5,7 +5,7 @@ script:
   - mkdir AppDir
   # Build software
   - sudo apt-get update
-  - sudo apt-get install -y build-essential gettext cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev libgspell-1-dev
+  - sudo apt-get install -y build-essential git gettext cmake valac libgee-0.8-dev libsqlite3-dev libgtk-3-dev libnotify-dev libgpgme-dev libsoup2.4-dev libgcrypt20-dev libqrencode-dev libgspell-1-dev
   - ./configure --with-libsignal-in-tree
   - make
   - make DESTDIR="$(pwd)/AppDir" prefix="/usr" install
@@ -33,6 +33,8 @@ AppDir:
 
     include:
       - sqlite3
+      - gettext
+      - glib-networking
       - libgee-0.8-2
       - libsqlite3-0
       - libnotify4
@@ -40,7 +42,10 @@ AppDir:
       - libsoup2.4-1
       - libgcrypt20
       - libqrencode4
-      - libgspell-1-2      
+      - libgspell-1-2
+      - libgdk-pixbuf2.0-0
+      - libpng16-16
+      - libicu66
     exclude: []
 
   runtime:


### PR DESCRIPTION
This is a draft, since I am still having issues when running on Debian 10 or Manjaro systems and I am not sure how to solve it.

Maybe someone has an idea, what is causing this error. It works fine on Ubuntu 20.04.

this is the error I am getting:
```
$ ./dino-0.2.0-x86_64.AppImage 

** (dino:2179): CRITICAL **: 15:33:33.473: file /home/runner/work/dino/dino/main/src/ui/main_window.vala: line 68: uncaught error: Unrecognized image file format (gdk-pixbuf-error-quark, 3)

(dino:2179): Gtk-WARNING **: 15:33:33.551: Could not load a pixbuf from icon theme.
This may indicate that pixbuf loaders or the mime database could not be found.
**
Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
Bail out! Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
Abgebrochen
```

This would solve #437, #941 and #278