### PR TITLE
Add unread indicator

### DIFF
--- a/main/data/theme.css
+++ b/main/data/theme.css
@@ -284,6 +284,10 @@ window.dino-main .dino-chatinput-button button:checked:backdrop {
     background-color: @theme_base_color;
 }
 
+.dino-unread-label {
+    color: @theme_selected_bg_color;
+}
+
 
 /*Chat input warning*/
 

--- a/main/src/ui/conversation_content_view/conversation_view.vala
+++ b/main/src/ui/conversation_content_view/conversation_view.vala
@@ -49,6 +49,8 @@ public class ConversationView : Widget, Plugins.ConversationItemCollection, Plug
         this.layout_manager = new BinLayout();
     }
 
+    private UnreadIndicatorItem? unread_indicator = null;
+
     public ConversationView init(StreamInteractor stream_interactor) {
         this.stream_interactor = stream_interactor;
         scrolled.vadjustment.notify["upper"].connect_after(on_upper_notify);
@@ -298,6 +300,7 @@ public class ConversationView : Widget, Plugins.ConversationItemCollection, Plug
         // Clear data structures
         clear_notifications();
         this.conversation = conversation;
+        this.unread_indicator = null;
 
         // Init for new conversation
         foreach (Plugins.ConversationItemPopulator populator in app.plugin_registry.conversation_addition_populators) {
@@ -315,11 +318,23 @@ public class ConversationView : Widget, Plugins.ConversationItemCollection, Plug
         foreach (ContentMetaItem item in items) {
             do_insert_item(item);
         }
+
+        update_unread_indicator();
+
         Application app = GLib.Application.get_default() as Application;
         foreach (Plugins.NotificationPopulator populator in app.plugin_registry.notification_populators) {
             populator.init(conversation, this, Plugins.WidgetType.GTK4);
         }
         Idle.add(() => { on_value_notify(); return false; });
+    }
+
+    private void update_unread_indicator() {
+        ContentItem? read_up_to_item = stream_interactor.get_module(ContentItemStore.IDENTITY).get_item_by_id(conversation, conversation.read_up_to_item);
+        int current_num_unread = stream_interactor.get_module(ChatInteraction.IDENTITY).get_num_unread(conversation);
+        if(read_up_to_item != null && current_num_unread > 0 && unread_indicator == null) {
+            unread_indicator = new UnreadIndicatorItem(read_up_to_item);
+            do_insert_item(unread_indicator);
+        }
     }
 
     public void insert_item(Plugins.MetaConversationItem item) {
@@ -331,6 +346,9 @@ public class ConversationView : Widget, Plugins.ConversationItemCollection, Plug
                 return;
             }
         }
+
+        update_unread_indicator();
+
         do_insert_item(item);
     }
 
@@ -534,6 +552,28 @@ public class ConversationView : Widget, Plugins.ConversationItemCollection, Plug
 //        notifications.@foreach((widget) => { notifications.remove(widget); });
         notification_revealer.transition_duration = 0;
         notification_revealer.set_reveal_child(false);
+    }
+}
+
+private class UnreadIndicatorItem : Plugins.MetaConversationItem {
+    public UnreadIndicatorItem(ContentItem after_item) {
+        this.time = after_item.time;
+        this.secondary_sort_indicator = int.MAX;
+    }
+
+    public override Object? get_widget(Plugins.ConversationItemWidgetInterface outer, Plugins.WidgetType type) {
+        Box box = new Box(Orientation.HORIZONTAL, 0) { hexpand=true, visible=true };
+        Label label = new Label("Unread") { use_markup=true, halign=Align.END, hexpand=false, visible=true };
+        label.get_style_context().add_class("dino-unread-label");
+        Separator sep = new Separator(Orientation.HORIZONTAL) { valign=Align.CENTER, hexpand=true, visible=true };
+        sep.get_style_context().add_class("dino-unread-label");
+        box.append(sep);
+        box.append(label);
+        return box;
+    }
+
+    public override Gee.List<Plugins.MessageAction>? get_item_actions(Plugins.WidgetType type) {
+       return null;
     }
 }
 


### PR DESCRIPTION
This should close #192

This is my first time working on dino or writing any Vala, so let me know if there's anything that's not great here.  It seems to work fine with my small amount of testing, but I'm not sure what to use for the unread indicator, right now I just have a Label as a placeholder.

Possible improvements:
- [x] Currently if you have a conversation open and new messages arrive, the unread indicator will not appear.  Not sure if this is desired.  Perhaps just when unfocused, more matching the behavior of the unread number in the convo list
- [ ] Jump to the unread message if it would be off the screen