### PR TITLE
Allow establishing connections in clear text

### DIFF
--- a/libdino/src/service/connection_manager.vala
+++ b/libdino/src/service/connection_manager.vala
@@ -198,6 +198,7 @@ public class ConnectionManager : Object {
 
             change_connection_state(account, ConnectionState.CONNECTING);
             stream_result = yield Xmpp.establish_stream(account.bare_jid, module_manager.get_modules(account, resource), log_options,
+                                                        Util.is_cleartext_allowed_for_host(account.bare_jid.domain_jid.to_string()),
                     (peer_cert, errors) => { return on_invalid_certificate(account.domainpart, peer_cert, errors); }
             );
             connections[account].stream = stream_result.stream;

--- a/libdino/src/service/registration.vala
+++ b/libdino/src/service/registration.vala
@@ -30,6 +30,7 @@ public class Register : StreamInteractionModule, Object{
         list.add(new Sasl.Module(account.bare_jid.to_string(), account.password));
 
         XmppStreamResult stream_result = yield Xmpp.establish_stream(account.bare_jid.domain_jid, list, Application.print_xmpp,
+                                                                     Util.is_cleartext_allowed_for_host(account.bare_jid.domain_jid.to_string()),
                 (peer_cert, errors) => { return ConnectionManager.on_invalid_certificate(account.domainpart, peer_cert, errors); }
         );
 
@@ -83,6 +84,7 @@ public class Register : StreamInteractionModule, Object{
         list.add(new Iq.Module());
 
         XmppStreamResult stream_result = yield Xmpp.establish_stream(jid.domain_jid, list, Application.print_xmpp,
+                                                                     Util.is_cleartext_allowed_for_host(jid.domain_jid.to_string()),
                 (peer_cert, errors) => { return ConnectionManager.on_invalid_certificate(jid.domainpart, peer_cert, errors); }
         );
 
@@ -137,6 +139,7 @@ public class Register : StreamInteractionModule, Object{
         list.add(new Xep.InBandRegistration.Module());
 
         XmppStreamResult stream_result = yield Xmpp.establish_stream(jid.domain_jid, list, Application.print_xmpp,
+                                                                     Util.is_cleartext_allowed_for_host(jid.domain_jid.to_string()),
                 (peer_cert, errors) => { return ConnectionManager.on_invalid_certificate(jid.domainpart, peer_cert, errors); }
         );
 
@@ -188,6 +191,7 @@ public class Register : StreamInteractionModule, Object{
         list.add(new Xep.InBandRegistration.Module());
 
         XmppStreamResult stream_result = yield Xmpp.establish_stream(jid.domain_jid, list, Application.print_xmpp,
+                                                                     Util.is_cleartext_allowed_for_host(jid.domain_jid.to_string()),
                 (peer_cert, errors) => { return ConnectionManager.on_invalid_certificate(jid.domainpart, peer_cert, errors); }
         );
 

--- a/libdino/src/service/util.vala
+++ b/libdino/src/service/util.vala
@@ -26,6 +26,11 @@ public class Util {
         }
         assert_not_reached();
     }
+
+    public static bool is_cleartext_allowed_for_host(string host) {
+        string cleartext_hosts = Environment.get_variable("DINO_CLEARTEXT_HOSTS");
+        return host in (cleartext_hosts != null ? cleartext_hosts : "localhost").split(",");
+    }
 }
 
 }

--- a/xmpp-vala/CMakeLists.txt
+++ b/xmpp-vala/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ENGINE_EXTRA_OPTIONS ${MAIN_EXTRA_OPTIONS} --vapidir=${CMAKE_CURRENT_SOURCE_
 
 vala_precompile(ENGINE_VALA_C
 SOURCES
+    "src/core/cleartext_xmpp_stream.vala"
     "src/core/direct_tls_xmpp_stream.vala"
     "src/core/io_xmpp_stream.vala"
     "src/core/module_flag.vala"

--- a/xmpp-vala/src/core/cleartext_xmpp_stream.vala
+++ b/xmpp-vala/src/core/cleartext_xmpp_stream.vala
@@ -1,0 +1,26 @@
+public class Xmpp.ClearTextXmppStream : TlsXmppStream {
+    string host;
+    uint16 port;
+
+    public ClearTextXmppStream(Jid remote, string host, uint16 port) {
+        base(remote);
+        this.host = host;
+        this.port = port;
+    }
+
+    public override async void connect() throws IOStreamError {
+        SocketClient client = new SocketClient();
+
+        debug("Connecting to %s:%i (cleartext)", host, port);
+        try {
+            IOStream stream = yield client.connect_to_host_async(host, port);
+            reset_stream(stream);
+
+            yield setup();
+
+            attach_negotation_modules();
+        } catch (Error e) {
+            throw new IOStreamError.CONNECT("Failed connecting to %s:%i (cleartext): %s", this.host, this.port, e.message);
+        }
+    }
+}

--- a/xmpp-vala/src/core/direct_tls_xmpp_stream.vala
+++ b/xmpp-vala/src/core/direct_tls_xmpp_stream.vala
@@ -14,7 +14,7 @@ public class Xmpp.DirectTlsXmppStream : TlsXmppStream {
     public override async void connect() throws IOStreamError {
         SocketClient client = new SocketClient();
         try {
-            debug("Connecting to %s %i (tls)", host, port);
+            debug("Connecting to %s:%i (tls)", host, port);
             IOStream? io_stream = yield client.connect_to_host_async(host, port);
             TlsConnection tls_connection = TlsClientConnection.new(io_stream, new NetworkAddress(remote_name.to_string(), port));
 #if ALPN_SUPPORT

--- a/xmpp-vala/src/core/starttls_xmpp_stream.vala
+++ b/xmpp-vala/src/core/starttls_xmpp_stream.vala
@@ -16,7 +16,7 @@ public class Xmpp.StartTlsXmppStream : TlsXmppStream {
     public override async void connect() throws IOStreamError {
         try {
             SocketClient client = new SocketClient();
-            debug("Connecting to %s %i (starttls)", host, port);
+            debug("Connecting to %s:%i (starttls)", host, port);
             IOStream stream = yield client.connect_to_host_async(host, port);
             reset_stream(stream);
 


### PR DESCRIPTION
Cleartext connection would have the lowest priority, so Dino would still try to connect via StartTLS or direct TLS first.

Allowed hostnames can be specified via the `DINO_CLEARTEXT_HOSTS` environment variable, separated by commas.

By default, only connections to `localhost` are allowed. This can be disabled by setting the variable to an empty value. If the variable gets set to any other value, `localhost` will not be included in the allow list automatically.