### PR TITLE
Reject non-TLS URLs in HTTP File Upload

### DIFF
--- a/xmpp-vala/src/module/xep/0363_http_file_upload.vala
+++ b/xmpp-vala/src/module/xep/0363_http_file_upload.vala
@@ -72,6 +72,11 @@ public class Module : XmppStreamModule {
                 Idle.add((owned) callback);
                 return;
             }
+            if (url_get.ascii_down(4).has_prefix("http://") || url_put.ascii_down(4).has_prefix("http://")) {
+                e = new HttpFileTransferError.SLOT_REQUEST("Error getting upload/download url: server is misconfigured and sent us a URL without TLS enabled");
+                Idle.add((owned) callback);
+                return;
+            }
 
             slot_result.headers = new HashMap<string, string>();
 

--- a/xmpp-vala/src/module/xep/0363_http_file_upload.vala
+++ b/xmpp-vala/src/module/xep/0363_http_file_upload.vala
@@ -72,8 +72,8 @@ public class Module : XmppStreamModule {
                 Idle.add((owned) callback);
                 return;
             }
-            if (url_get.ascii_down(4).has_prefix("http://") || url_put.ascii_down(4).has_prefix("http://")) {
-                e = new HttpFileTransferError.SLOT_REQUEST("Error getting upload/download url: server is misconfigured and sent us a URL without TLS enabled");
+            if (!url_get.down().has_prefix("https://") || !url_put.down().has_prefix("https://")) {
+                e = new HttpFileTransferError.SLOT_REQUEST("Error getting upload/download url: Received non-https URL from server");
                 Idle.add((owned) callback);
                 return;
             }


### PR DESCRIPTION
This is a MUST in the XEP.

Fixes #697.