### PR TITLE
Format quotes as preformatted text

### DIFF
--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -341,6 +341,19 @@ public static string parse_add_markup(string s_, string? highlight_word, bool pa
                 assert_not_reached();
             }
         }
+
+        Regex regex = new Regex("((?<=\n)&gt;.*(\n|$))|(^&gt;.*(\n|$))");
+        MatchInfo match_info;
+        regex.match(s.down(), 0, out match_info);
+
+        if (match_info.matches()) {
+            int start, end;
+
+            match_info.fetch_pos(0, out start, out end);
+            return parse_add_markup(s[0:start], highlight_word, parse_links, parse_text_markup, already_escaped) +
+                "<span fgalpha='70%'>" + s[start:end] + "</span>" +
+                parse_add_markup(s[end:s.length], highlight_word, parse_links, parse_text_markup, already_escaped);
+        }
     }
 
     return s;


### PR DESCRIPTION
This is a little nice feature from Conversations that I had always missed on Dino. A regular expression, based on the one used by [`feature/quote`](https://github.com/MarcoPolo-PasTonMolo/dino/blob/feature/quote/main/src/ui/conversation_view.vala#L27), finds matching quotes. Then, quotes are rendered using the Pango markup language with preformatted text and a specific background colour, while leaving other text with default formatting.
![image](https://user-images.githubusercontent.com/25252461/134247398-f857a0b7-7e00-40bc-8009-ba278c0e96df.png)
As a suggestion, merging https://github.com/dino/dino/pull/1097 along with this PR shall provide Dino with full support for quotes.

Please feel free to suggest any other better-looking format than the one suggested above.