### PR TITLE
fix screenshot dimensions in appdata.xml

### DIFF
--- a/main/data/im.dino.Dino.appdata.xml
+++ b/main/data/im.dino.Dino.appdata.xml
@@ -140,13 +140,13 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image height="900" width="1600">https://dino.im/img/appdata/main.png</image>
+      <image height="950" width="1600">https://dino.im/img/appdata/main.png</image>
     </screenshot>
     <screenshot>
-      <image height="900" width="1600">https://dino.im/img/appdata/start_chat.png</image>
+      <image height="942" width="1600">https://dino.im/img/appdata/start_chat.png</image>
     </screenshot>
     <screenshot>
-      <image height="900" width="1600">https://dino.im/img/appdata/contact_details.png</image>
+      <image height="1188" width="2018">https://dino.im/img/appdata/contact_details.png</image>
     </screenshot>
   </screenshots>
   <translation type="gettext">dino</translation>

--- a/main/data/im.dino.Dino.appdata.xml.in
+++ b/main/data/im.dino.Dino.appdata.xml.in
@@ -13,13 +13,13 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image height="900" width="1600">https://dino.im/img/appdata/main.png</image>
+      <image height="950" width="1600">https://dino.im/img/appdata/main.png</image>
     </screenshot>
     <screenshot>
-      <image height="900" width="1600">https://dino.im/img/appdata/start_chat.png</image>
+      <image height="942" width="1600">https://dino.im/img/appdata/start_chat.png</image>
     </screenshot>
     <screenshot>
-      <image height="900" width="1600">https://dino.im/img/appdata/contact_details.png</image>
+      <image height="1088" width="2018">https://dino.im/img/appdata/contact_details.png</image>
     </screenshot>
   </screenshots>
   <translation type="gettext">dino</translation>


### PR DESCRIPTION
The dimensions mentioned in the appdata.xml files don't match the dimensions of the files on the website anymore, so the validation step fails when building an appimage using the [linuxdeploy](https://github.com/linuxdeploy/linuxdeploy) AppImage resp. it's integrated appimage binary:
```
[appimage/stdout] Trying to validate AppStream information with the appstream-util tool
[appimage/stdout] In case of issues, please refer to https://github.com/hughsie/appstream-glib
[appimage/stdout] /home/alexander/src/appimage/dino-0.2.2/build/Dino.AppDir/usr/share/metainfo/im.dino.Dino.appdata.xml: FEHLGESCHLAGEN:
[appimage/stdout] • attribute-invalid     : <screenshot> height (900) did not match specified (950) [https://dino.im/img/appdata/main.png]
[appimage/stdout] • attribute-invalid     : <screenshot> height (900) did not match specified (942) [https://dino.im/img/appdata/start_chat.png]
[appimage/stdout] • attribute-invalid     : <screenshot> width (1600) did not match specified (2018) [https://dino.im/img/appdata/contact_details.png]
[appimage/stdout] • attribute-invalid     : <screenshot> height (900) did not match specified (1188) [https://dino.im/img/appdata/contact_details.png]
[appimage/stdout] run_external: subprocess exited with status 1[appimage/stderr] Validierung der Dateien ist fehlgeschlagen
[appimage/stderr] Failed to validate AppStream information with appstream-util
ERROR: Failed to run plugin: appimage (exit code: 1) 
```

Is there a process that ensures that changes to the screenshots on your website are reflected in those files?