### PR TITLE
Remove border around image file prevews

### DIFF
--- a/main/data/theme.css
+++ b/main/data/theme.css
@@ -111,11 +111,6 @@ window.dino-main .call-box {
     margin: 12px 16px 12px 12px;
 }
 
-window.dino-main .file-image-widget {
-    border: 1px solid alpha(@theme_fg_color, 0.1);
-    border-radius: 3px;
-}
-
 window.dino-main .file-image-widget .file-box-outer {
     color: #eee;
     background: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
Images with transparent background look much, much prettier when borderless (especially when emulating stickers), and opaque images made the border not visible anyway, so no change there.