### PR TITLE
Allow to retry failed file receipts

### DIFF
--- a/main/src/ui/conversation_content_view/file_widget.vala
+++ b/main/src/ui/conversation_content_view/file_widget.vala
@@ -194,11 +194,12 @@ public class FileDefaultWidgetController : Object {
                 }
                 break;
             case FileTransfer.State.NOT_STARTED:
+            case FileTransfer.State.FAILED:
                 assert(stream_interactor != null && file_transfer != null);
                 stream_interactor.get_module(FileManager.IDENTITY).download_file.begin(file_transfer);
                 break;
             default:
-                // Clicking doesn't do anything in FAILED and IN_PROGRESS states
+                // Clicking doesn't do anything in IN_PROGRESS state
                 break;
         }
         return false;


### PR DESCRIPTION
I only tested on a failed http download, no jingle transfers.

Partially addresses #1125.