### PR TITLE
conversation_view.vala: update_highlight on touch event

### DIFF
--- a/main/src/ui/conversation_content_view/conversation_view.vala
+++ b/main/src/ui/conversation_content_view/conversation_view.vala
@@ -73,6 +73,8 @@ public class ConversationView : Box, Plugins.ConversationItemCollection, Plugins
         // the pointer motion events as long as the pointer is above the message menu.
         // This ensures that the currently highlighted item remains unchanged when the pointer
         // reaches the overlapping part of a button.
+        main_wrap_event_box.events = EventMask.TOUCH_MASK;
+        main_wrap_event_box.touch_event.connect(on_touch_event);
         main_event_box.events = EventMask.POINTER_MOTION_MASK;
         main_event_box.motion_notify_event.connect(on_motion_notify_event);
 
@@ -100,6 +102,11 @@ public class ConversationView : Box, Plugins.ConversationItemCollection, Plugins
             }
             iter.previous();
         }
+    }
+
+    private bool on_touch_event(Gdk.Event event) {
+        update_highlight((int)event.touch.x_root, (int)event.touch.y_root);
+        return false;
     }
 
     private bool on_enter_notify_event(Gdk.EventCrossing event) {


### PR DESCRIPTION
Mobile devices such as the PinePhone do not receive leave/enter events for some reason, so actions such as editing a previous message are not possible unless a keyboard shortcut is used, which not be as convenient or even possible under some DEs. As a workaround, `TOUCH_MASK` can be used for the same purpose instead.

This commit should not affect desktop platforms with mouse or touchpad.