### PR TITLE
Display friendlier xmpp: links when a jid is in the roster

### DIFF
--- a/main/src/ui/conversation_content_view/message_widget.vala
+++ b/main/src/ui/conversation_content_view/message_widget.vala
@@ -94,7 +94,17 @@ public class MessageMetaItem : ContentMetaItem {
         if (conversation.type_ == Conversation.Type.GROUPCHAT) {
             markup_text = Util.parse_add_markup_theme(markup_text, conversation.nickname, true, true, true, Util.is_dark_theme(this.label), ref theme_dependent);
         } else {
-            markup_text = Util.parse_add_markup_theme(markup_text, null, true, true, true, Util.is_dark_theme(this.label), ref theme_dependent);
+            Util.LinkDisplay roster_lookup = (uri) => {
+                string? s = null;
+                if (GLib.Uri.parse_scheme(uri) == "xmpp") {
+                    try {
+                        Jid? j = new Jid(uri["xmpp:".length:uri.length]);
+                        s = Dino.get_real_display_name(stream_interactor, conversation.account, j);
+                    } catch (InvalidJidError e) { /* it's fine */ }
+                }
+                return s;
+            };
+            markup_text = Util.parse_add_markup_theme(markup_text, null, true, true, true, Util.is_dark_theme(this.label), ref theme_dependent, false, roster_lookup);
         }
 
         if (message.body.has_prefix("/me ")) {


### PR DESCRIPTION
    In jabber chats, there may be cases where an xmpp link is a valid
    JID that's in an account's roster. For example, Cheogram's jmp.chat
    service uses xmpp: links to support SMS group chat over jabber. They
    overlay a group chat over an individual chat by having the list of
    phone numbers as the chat contact JID (eg, a JID of
    "+11111111111,+13333333333@cheogram.com" for a group chat between
    someone with the phone number (111) 111-1111, another person with
    the number (333) 333-3333, and whatever the user's phone number is),
    and each message in the chat window that is received is prefixed with
    an xmpp: link that has just the single phone number of the sender (eg,
    "<xmpp:+111111111111@cheogram.com> " for (111) 111-1111). That JID
    that's in the message body is the same one that's used for 1-to-1 SMS
    chats, so it is likely to be in the user's roster as a contact.
    
    The JIDs aren't particularly legible or memorable, so we'd instead
    like to display the name that's in the roster while keeping the xmpp
    link as clickable. In order to do that, this patch modifies
    Util.parse_add_markup_theme() (since that's where the <a> html tag
    markup is created) to add a callback function that takes a uri and
    returns what the <a> tag should display. If the callback returns null,
    we just stick with the default behavior of just displaying the raw
    xmpp link. However, if the uri includes a JID that's in the user's
    roster, we return the name that's in the roster.
    Util.parse_add_markup_theme() then uses that returned name in the <a>
    tag.
    
    A callback is used in order to keep the lookup generic, for future
    uses. While the call to Util.parse_add_markup_theme() inside of
    MessageItemWidget::generate_markup_text()'s non-MUC code has a
    callback that specifically only checks for xmpp: links, there's no
    reason that it needs to be limited to that. It could handle any link;
    for example, translating an http:// link to that same link but with
    an "(insecure)" string added to it.