### PR TITLE
set a generic MIME type for encrypted file

### DIFF
--- a/plugins/omemo/src/file_transfer/file_encryptor.vala
+++ b/plugins/omemo/src/file_transfer/file_encryptor.vala
@@ -38,7 +38,7 @@ public class OmemoFileEncryptor : Dino.FileEncryptor, Object {
             omemo_http_file_meta.iv = iv;
             omemo_http_file_meta.key = key;
             omemo_http_file_meta.size = file_transfer.size + 16;
-            omemo_http_file_meta.mime_type = "omemo";
+            omemo_http_file_meta.mime_type = "application/octet-stream";
             file_transfer.input_stream = new ConverterInputStream(file_transfer.input_stream, new SymmetricCipherEncrypter((owned) cipher, 16));
         } catch (Crypto.Error error) {
             throw new FileSendError.ENCRYPTION_FAILED("OMEMO file encryption error: %s".printf(error.message));


### PR DESCRIPTION
This sets a valid but generic MIME type for OMEMO encrypted files. 
*application/octet-stream* though valid MIME type for the encrypted stream, doesn't tell the exact MIME type of the encrypted file thus serves the purpose.

Closes #1116 