### PR TITLE
Send idle presence on screen lock event

### DIFF
--- a/libdino/src/dbus/login1.vala
+++ b/libdino/src/dbus/login1.vala
@@ -3,11 +3,26 @@ namespace Dino {
 [DBus (name = "org.freedesktop.login1.Manager")]
 public interface Login1Manager : Object {
     public signal void PrepareForSleep(bool suspend);
+    public abstract GLib.ObjectPath get_session(string session_id) throws DBusError, IOError;
 }
 
 public static async Login1Manager? get_login1() {
     try {
         return yield Bus.get_proxy(BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1");
+    } catch (IOError e) {
+        stderr.printf("%s\n", e.message);
+    }
+    return null;
+}
+
+[DBus (name = "org.freedesktop.login1.Session")]
+public interface Login1Session : Object {
+    public abstract bool locked_hint {  get; }
+}
+
+public static async Login1Session? get_login1_session(string session) {
+    try {
+        return yield Bus.get_proxy(BusType.SYSTEM, "org.freedesktop.login1", session);
     } catch (IOError e) {
         stderr.printf("%s\n", e.message);
     }

--- a/libdino/src/service/presence_manager.vala
+++ b/libdino/src/service/presence_manager.vala
@@ -25,6 +25,13 @@ public class PresenceManager : StreamInteractionModule, Object {
     private PresenceManager(StreamInteractor stream_interactor) {
         this.stream_interactor = stream_interactor;
         stream_interactor.account_added.connect(on_account_added);
+        stream_interactor.connection_manager.session_locked_hint.connect((locked) => {
+            if (locked) {
+                stream_interactor.connection_manager.change_show_all(Xmpp.Presence.Stanza.SHOW_AWAY);
+            } else {
+                stream_interactor.connection_manager.change_show_all(Xmpp.Presence.Stanza.SHOW_ONLINE);
+            }
+        });
     }
 
     public string? get_last_show(Jid jid, Account account) {

--- a/xmpp-vala/src/module/presence/stanza.vala
+++ b/xmpp-vala/src/module/presence/stanza.vala
@@ -69,7 +69,7 @@ public class Stanza : Xmpp.Stanza {
                     show_node = new StanzaNode.build(NODE_SHOW);
                     stanza.put_node(show_node);
                 }
-                show_node.val = value;
+                show_node.put_node(new StanzaNode.text(value));
             }
         }
     }
@@ -78,7 +78,13 @@ public class Stanza : Xmpp.Stanza {
         get {
             return base.type_ ?? TYPE_AVAILABLE;
         }
-        set { base.type_ = value; }
+        set {
+            if (value == TYPE_AVAILABLE) {
+                base.type_ = null;
+            } else {
+                base.type_ = value;
+            }
+        }
     }
 
     public Stanza(string? id = null) {


### PR DESCRIPTION
Fixes #715 

Connects to the login1 session to access the LockedHint property
Tested with two dino clients on separate devices
I mostly improvised where to add a new class/member/signal, so please give feedback whether I should relocate code to somewhere else :)