### PR TITLE
Support devices with multiple framerate options in get_max_fps

### DIFF
--- a/plugins/rtp/src/plugin.vala
+++ b/plugins/rtp/src/plugin.vala
@@ -382,9 +382,27 @@ public class Dino.Plugins.Rtp.Plugin : RootInterface, VideoCallPlugin, Object {
         int fps = 0;
         for (int i = 0; i < device.device.caps.get_size(); i++) {
             unowned Gst.Structure structure = device.device.caps.get_structure(i);
-            int num = 0, den = 0;
-            if (structure.has_field("framerate") && structure.get_fraction("framerate", out num, out den)) fps = int.max(fps, num / den);
+
+            if (structure.has_field("framerate")) {
+                Value framerate = structure.get_value("framerate");
+                if (framerate.type() == typeof(Gst.Fraction)) {
+                    int num = Gst.Value.get_fraction_numerator(framerate);
+                    int den = Gst.Value.get_fraction_denominator(framerate);
+                    fps = int.max(fps, num / den);
+                } else if (framerate.type() == typeof(Gst.ValueList)) {
+                    for(uint j = 0; j < Gst.ValueList.get_size(framerate); j++) {
+                        Value fraction = Gst.ValueList.get_value(framerate, j);
+                        int num = Gst.Value.get_fraction_numerator(fraction);
+                        int den = Gst.Value.get_fraction_denominator(fraction);
+                        fps = int.max(fps, num / den);
+                    }
+                } else {
+                    debug("Unknown type for framerate %s on device %s", framerate.type_name(), device.display_name);
+                }
+            }
         }
+
+        debug("Max framerate for device %s: %d", device.display_name, fps);
         return fps;
     }
 


### PR DESCRIPTION
Some video devices will report framerate as a single value:
![image](https://user-images.githubusercontent.com/901583/164109188-f25945c1-4ae6-473d-8970-7e2c34bb3196.png)

And others will report framerate as a list of options:
![image](https://user-images.githubusercontent.com/901583/164108971-b339abb5-a308-475e-be9f-013771f8def5.png)

At the time of writing, dino only works with the former. When attempting to video call using a device that has multiple framerates, get_max_fps will return zero and as a result dino won't find any video devices to use.

This PR should support both cases properly. 

Note that I also had to apply the patch in #1195 to make this work as well, as the correct framerate was not obtained for use in the video call without it.
