### PR TITLE
Show warning dialog on failed GTK video sink creation

### DIFF
--- a/plugins/rtp/src/video_widget.vala
+++ b/plugins/rtp/src/video_widget.vala
@@ -41,6 +41,14 @@ public class Dino.Plugins.Rtp.VideoWidget : Gtk.Bin, Dino.Plugins.VideoCallWidge
             add(widget);
             widget.visible = true;
         } else {
+            var dialog = new Gtk.MessageDialog(null, MODAL, WARNING, OK, null);
+
+            dialog.text = "Could not create GTK video sink";
+            dialog.secondary_text = "Please install package gstreamer1.0-gtk3 or equivalent.";
+            dialog.response.connect((response_id) => {
+                dialog.close();
+            });
+            dialog.run();
             warning("Could not create GTK video sink. Won't display videos.");
         }
         size_allocate.connect_after(after_size_allocate);


### PR DESCRIPTION
## Background

Dino depends on `gstreamer1.0-gtk3` (or equivalent package provided by the distribution) be available on the host system in order to allow [`video_widget.vala`](https://github.com/dino/dino/blob/99c076254abc6e2b03b784732a76a389e5a4f801/plugins/rtp/src/video_widget.vala#L32) to create GTK video sinks, which are used for video calls. Unfortunately, such requirement was not specified anywhere and, since this is a runtime (rather than build time) requirement, Dino would still build without issues.

Moreover, Dino would only return a lousy warning message over `stderr` instead of showing a warning dialog, so it would be visible to users running Dino from the command line only.

## Implementation

In order to assist users with this issue, this PR suggests to display a more informative `Gtk.MessageDialog` to those running Dino without `gstreamer1.0-gtk3`, as shown below:

![image](https://user-images.githubusercontent.com/25252461/168448363-bdd1f298-c223-4544-b111-00f9cf7b0292.png)

