### PR TITLE
Add send button on chat view

### DIFF
--- a/libdino/src/entity/settings.vala
+++ b/libdino/src/entity/settings.vala
@@ -12,6 +12,7 @@ public class Settings : Object {
         notifications_ = col_to_bool_or_default("notifications", true);
         convert_utf8_smileys_ = col_to_bool_or_default("convert_utf8_smileys", true);
         check_spelling = col_to_bool_or_default("check_spelling", true);
+        send_button = col_to_bool_or_default("send_button", false);
     }
 
     private bool col_to_bool_or_default(string key, bool def) {
@@ -76,6 +77,20 @@ public class Settings : Object {
                 .value(db.settings.value, value.to_string())
                 .perform();
             check_spelling_ = value;
+        }
+    }
+
+    public signal void send_button_update();
+    private bool send_button_;
+    public bool send_button {
+        get { return send_button_; }
+        set {
+            db.settings.upsert()
+                .value(db.settings.key, "send_button", true)
+                .value(db.settings.value, value.to_string())
+                .perform();
+            send_button_ = value;
+            send_button_update();
         }
     }
 }

--- a/main/data/chat_input.ui
+++ b/main/data/chat_input.ui
@@ -23,7 +23,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="margin-top">3</property>
                                 <property name="relief">none</property>
-                                <property name="valign">start</property>
+                                <property name="valign">center</property>
                                 <property name="visible">True</property>
                                 <style>
                                     <class name="flat"/>

--- a/main/data/settings_dialog.ui
+++ b/main/data/settings_dialog.ui
@@ -77,6 +77,18 @@
                                 <property name="height">1</property>
                             </packing>
                         </child>
+                        <child>
+                            <object class="GtkCheckButton" id="send_button_checkbutton">
+                                <property name="label" translatable="yes">Enable send button</property>
+                                <property name="visible">True</property>
+                            </object>
+                            <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">5</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
+                            </packing>
+                        </child>
                     </object>
                 </child>
             </object>

--- a/main/src/ui/chat_input/chat_text_view.vala
+++ b/main/src/ui/chat_input/chat_text_view.vala
@@ -76,7 +76,9 @@ public class ChatTextView : ScrolledWindow {
 
     private bool on_text_input_key_press(EventKey event) {
         if (event.keyval in new uint[]{Key.Return, Key.KP_Enter}) {
-            if ((event.state & ModifierType.SHIFT_MASK) > 0) {
+            Dino.Entities.Settings settings = Dino.Application.get_default().settings;
+
+            if ((event.state & ModifierType.SHIFT_MASK) > 0 || settings.send_button) {
                 text_view.buffer.insert_at_cursor("\n", 1);
             } else if (text_view.buffer.text.strip() != "") {
                 send_text();

--- a/main/src/ui/chat_input/view.vala
+++ b/main/src/ui/chat_input/view.vala
@@ -31,7 +31,7 @@ public class View : Box {
     public View init(StreamInteractor stream_interactor) {
         this.stream_interactor = stream_interactor;
 
-        encryption_widget = new EncryptionButton(stream_interactor) { relief=ReliefStyle.NONE, margin_top=3, valign=Align.START, visible=true };
+        encryption_widget = new EncryptionButton(stream_interactor) { relief=ReliefStyle.NONE, margin_top=3, valign=Align.CENTER, visible=true };
 
         file_button.get_style_context().add_class("dino-attach-button");
 
@@ -39,7 +39,7 @@ public class View : Box {
 
         // Emoji button for emoji picker (recents don't work < 3.22.19, category icons don't work <3.23.2)
         if (Gtk.get_major_version() >= 3 && Gtk.get_minor_version() >= 24) {
-            MenuButton emoji_button = new MenuButton() { relief=ReliefStyle.NONE, margin_top=3, valign=Align.START, visible=true };
+            MenuButton emoji_button = new MenuButton() { relief=ReliefStyle.NONE, margin_top=3, valign=Align.CENTER, visible=true };
             emoji_button.get_style_context().add_class("flat");
             emoji_button.get_style_context().add_class("dino-chatinput-button");
             emoji_button.image = new Image.from_icon_name("dino-emoticon-symbolic", IconSize.BUTTON) { visible=true };
@@ -54,6 +54,44 @@ public class View : Box {
         }
 
         outer_box.add(encryption_widget);
+
+        Dino.Entities.Settings settings = Dino.Application.get_default().settings;
+
+        MenuButton send_button = new MenuButton() {
+            tooltip_text="Send message",
+            relief=ReliefStyle.NONE,
+            margin_top=3,
+            valign=Align.CENTER,
+            visible=settings.send_button,
+            sensitive=false
+        };
+
+        settings.send_button_update.connect(() => {
+            send_button.visible = settings.send_button;
+        });
+
+        send_button.get_style_context().add_class("flat");
+        send_button.get_style_context().add_class("dino-chatinput-button");
+        send_button.image = new Image.from_icon_name("document-send", IconSize.BUTTON) {
+            visible=true,
+            icon_size=3
+        };
+
+        chat_text_view.text_view.buffer.changed.connect(() => {
+            if (chat_text_view.text_view.buffer.text != "") {
+                send_button.sensitive = true;
+            }
+            else {
+                send_button.sensitive = false;
+            }
+        });
+
+        send_button.button_release_event.connect(() => {
+            chat_text_view.send_text();
+            return true;
+        });
+
+        outer_box.add(send_button);
 
         Util.force_css(frame, "* { border-radius: 3px; }");
 

--- a/main/src/ui/settings_dialog.vala
+++ b/main/src/ui/settings_dialog.vala
@@ -10,6 +10,7 @@ class SettingsDialog : Dialog {
     [GtkChild] private unowned CheckButton notification_checkbutton;
     [GtkChild] private unowned CheckButton emoji_checkbutton;
     [GtkChild] private unowned CheckButton check_spelling_checkbutton;
+    [GtkChild] private unowned CheckButton send_button_checkbutton;
 
     Dino.Entities.Settings settings = Dino.Application.get_default().settings;
 
@@ -21,12 +22,14 @@ class SettingsDialog : Dialog {
         notification_checkbutton.active = settings.notifications;
         emoji_checkbutton.active = settings.convert_utf8_smileys;
         check_spelling_checkbutton.active = settings.check_spelling;
+        send_button_checkbutton.active = settings.send_button;
 
         typing_checkbutton.toggled.connect(() => { settings.send_typing = typing_checkbutton.active; } );
         marker_checkbutton.toggled.connect(() => { settings.send_marker = marker_checkbutton.active; } );
         notification_checkbutton.toggled.connect(() => { settings.notifications = notification_checkbutton.active; } );
         emoji_checkbutton.toggled.connect(() => { settings.convert_utf8_smileys = emoji_checkbutton.active; });
         check_spelling_checkbutton.toggled.connect(() => { settings.check_spelling = check_spelling_checkbutton.active; });
+        send_button_checkbutton.toggled.connect(() => { settings.send_button = send_button_checkbutton.active; });
     }
 }
 


### PR DESCRIPTION
## Background

On some specific devices e.g.: PinePhone, using the current key combination to introduce a `\n` character to a chat (i.e., `Shift+Enter`) is not possible from a virtual keyboard, such as [`squeekboard`](https://gitlab.gnome.org/World/Phosh/squeekboard). On the other hand, mobile-friendly instant messaging applications such as [Conversations](https://conversations.im) feature a send button, instead of using the `Enter` key for such purpose.

## Overview

As the title suggests, this PR adds a send button (using the `document-send` icon) to the right side of the chat view. The button is only sensitive if the chat message box is not empty:

![image](https://user-images.githubusercontent.com/25252461/168449374-c7a4d794-0f3e-4cdf-9a6c-6440ac4c1b33.png)
![image](https://user-images.githubusercontent.com/25252461/168449400-df428faf-c002-4ef3-a143-5dcf42898ddb.png)

When the send button is enabled, the `Enter` key can be used to introduce a `\n` character:

![image](https://user-images.githubusercontent.com/25252461/168449503-8cf02109-e8cf-4069-9438-124ddf8ab188.png)

In order not to break existing behaviour, the button is optional and disabled by default, and it can be enabled from the settings menu, as shown below. Likewise to other available settings, send button settings are persistently stored into the database.

![image](https://user-images.githubusercontent.com/25252461/168449331-3132758e-9619-4000-b315-1df932e6bc6d.png)
