### PR TITLE
User-selectable default encryption settings

### DIFF
--- a/libdino/src/entity/conversation.vala
+++ b/libdino/src/entity/conversation.vala
@@ -32,7 +32,7 @@ public class Conversation : Object {
             }
         }
     }
-    public Encryption encryption { get; set; default = Encryption.NONE; }
+    public Encryption encryption { get; set; default = Encryption.UNKNOWN; }
     public Message? read_up_to { get; set; }
     public int read_up_to_item { get; set; default=-1; }
 

--- a/libdino/src/entity/encryption.vala
+++ b/libdino/src/entity/encryption.vala
@@ -6,7 +6,28 @@ public enum Encryption {
         OMEMO,
         DTLS_SRTP,
         SRTP,
-        UNKNOWN,
+        UNKNOWN;
+
+        public static Encryption parse(string str) {
+                switch (str) {
+                        case "DINO_ENTITIES_ENCRYPTION_NONE":
+                                return NONE;
+                        case "DINO_ENTITIES_ENCRYPTION_PGP":
+                                return PGP;
+                        case "DINO_ENTITIES_ENCRYPTION_OMEMO":
+                                return OMEMO;
+                        case "DINO_ENTITIES_ENCRYPTION_DTLS_SRTP":
+                                return DTLS_SRTP;
+                        case "DINO_ENTITIES_ENCRYPTION_SRTP":
+                                return SRTP;
+                        case "DINO_ENTITIES_ENCRYPTION_UNKNOWN":
+                                // Fall through.
+                        default:
+                                break;
+                }
+
+                return UNKNOWN;
+        }
 }
 
 }

--- a/libdino/src/entity/settings.vala
+++ b/libdino/src/entity/settings.vala
@@ -12,11 +12,18 @@ public class Settings : Object {
         notifications_ = col_to_bool_or_default("notifications", true);
         convert_utf8_smileys_ = col_to_bool_or_default("convert_utf8_smileys", true);
         check_spelling = col_to_bool_or_default("check_spelling", true);
+        default_encryption = col_to_encryption_or_default("default_encryption", Encryption.UNKNOWN);
     }
 
     private bool col_to_bool_or_default(string key, bool def) {
         string? val = db.settings.select({db.settings.value}).with(db.settings.key, "=", key)[db.settings.value];
         return val != null ? bool.parse(val) : def;
+    }
+
+    private Encryption col_to_encryption_or_default(string key, Encryption def) {
+        var sval = db.settings.value;
+        string? val = db.settings.select({sval}).with(db.settings.key, "=", key)[sval];
+        return val != null ? Encryption.parse(val) : def;
     }
 
     private bool send_typing_;
@@ -76,6 +83,19 @@ public class Settings : Object {
                 .value(db.settings.value, value.to_string())
                 .perform();
             check_spelling_ = value;
+        }
+    }
+
+    private Encryption default_encryption_;
+    public Encryption default_encryption {
+        get { return default_encryption_; }
+        set {
+            string valstr = value.to_string();
+            db.settings.upsert()
+                .value(db.settings.key, "default_encryption", true)
+                .value(db.settings.value, valstr)
+                .perform();
+            default_encryption_ = value;
         }
     }
 }

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -64,6 +64,7 @@ set(RESOURCE_LIST
     conversation_list_titlebar_csd.ui
     conversation_row.ui
     conversation_view.ui
+    default_encryption_dialog.ui
     file_default_widget.ui
     file_send_overlay.ui
     emojichooser.ui

--- a/main/data/default_encryption_dialog.ui
+++ b/main/data/default_encryption_dialog.ui
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.6"/>
+  <object class="GtkDialog" id="dialog">
+    <property name="can_focus">False</property>
+    <property name="modal">True</property>
+    <property name="default_width">320</property>
+    <property name="default_height">260</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="accept_button">
+                <property name="label" translatable="yes">OK</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="default_encryption_warning_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xpad">10</property>
+                <property name="ypad">10</property>
+                <property name="label" translatable="yes">No default end-to-end encryption method has been previously selected for this conversation. XMPP defines some XEP for end-to-end encryption that Dino supports.
+
+It is strongly recommended that one of the following end-to-end encryption methods below is selected before sending a message.
+
+TAKE INTO ACCOUNT UNENCRYPTED CONVERSATIONS COULD BE READ BY THIRD PARTIES.
+
+These settings can be later changed from the Settings menu.</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="omemo">
+                <property name="label" translatable="yes">OMEMO (XEP-0384)</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="openpgp">
+                <property name="label" translatable="yes">OpenPGP (XEP-0027)</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">omemo</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="none">
+                <property name="label" translatable="yes">Unencrypted (not recommended)</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">omemo</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/main/data/settings_dialog.ui
+++ b/main/data/settings_dialog.ui
@@ -77,6 +77,77 @@
                                 <property name="height">1</property>
                             </packing>
                         </child>
+                        <child>
+                            <object class="GtkBox" id ="default_encryption_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                <object class="GtkLabel">
+                                    <property name="label" translatable="yes">Default encryption</property>
+                                    <property name="visible">True</property>
+                                </object>
+                                <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                </packing>
+                                </child>
+                                <child>
+                                <object class="GtkRadioButton" id="encryption_radio_undecided">
+                                    <property name="label" translatable="yes">Ask</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="active">True</property>
+                                    <property name="draw_indicator">True</property>
+                                    <property name="group">encryption_radio_undecided</property>
+                                </object>
+                                <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                </packing>
+                                </child>
+                                <child>
+                                <object class="GtkRadioButton" id="encryption_radio_omemo">
+                                    <property name="label" translatable="yes">OMEMO</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="active">True</property>
+                                    <property name="draw_indicator">True</property>
+                                    <property name="group">encryption_radio_undecided</property>
+                                </object>
+                                <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                </packing>
+                                </child>
+                                <child>
+                                <object class="GtkRadioButton" id="encryption_radio_openpgp">
+                                    <property name="label" translatable="yes">OpenPGP</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="active">True</property>
+                                    <property name="draw_indicator">True</property>
+                                    <property name="group">encryption_radio_undecided</property>
+                                </object>
+                                <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">3</property>
+                                </packing>
+                                </child>
+                            </object>
+                            <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">5</property>
+                                <property name="width">1</property>
+                                <property name="height">1</property>
+                            </packing>
+                        </child>
                     </object>
                 </child>
             </object>

--- a/main/src/ui/settings_dialog.vala
+++ b/main/src/ui/settings_dialog.vala
@@ -1,4 +1,5 @@
 using Gtk;
+using Dino.Entities;
 
 namespace Dino.Ui {
 
@@ -10,6 +11,9 @@ class SettingsDialog : Dialog {
     [GtkChild] private unowned CheckButton notification_checkbutton;
     [GtkChild] private unowned CheckButton emoji_checkbutton;
     [GtkChild] private unowned CheckButton check_spelling_checkbutton;
+    [GtkChild] private unowned RadioButton encryption_radio_undecided;
+    [GtkChild] private unowned RadioButton encryption_radio_omemo;
+    [GtkChild] private unowned RadioButton encryption_radio_openpgp;
 
     Dino.Entities.Settings settings = Dino.Application.get_default().settings;
 
@@ -21,12 +25,33 @@ class SettingsDialog : Dialog {
         notification_checkbutton.active = settings.notifications;
         emoji_checkbutton.active = settings.convert_utf8_smileys;
         check_spelling_checkbutton.active = settings.check_spelling;
+        encryption_radio_undecided.active = settings.default_encryption == Encryption.UNKNOWN;
+        encryption_radio_omemo.active = settings.default_encryption == Encryption.OMEMO;
+        encryption_radio_openpgp.active = settings.default_encryption == Encryption.PGP;
 
         typing_checkbutton.toggled.connect(() => { settings.send_typing = typing_checkbutton.active; } );
         marker_checkbutton.toggled.connect(() => { settings.send_marker = marker_checkbutton.active; } );
         notification_checkbutton.toggled.connect(() => { settings.notifications = notification_checkbutton.active; } );
         emoji_checkbutton.toggled.connect(() => { settings.convert_utf8_smileys = emoji_checkbutton.active; });
         check_spelling_checkbutton.toggled.connect(() => { settings.check_spelling = check_spelling_checkbutton.active; });
+
+        encryption_radio_undecided.toggled.connect(() => {
+            if (encryption_radio_undecided.active) {
+                settings.default_encryption = Encryption.UNKNOWN;
+            }
+        });
+
+        encryption_radio_omemo.toggled.connect(() => {
+            if (encryption_radio_omemo.active) {
+                settings.default_encryption = Encryption.OMEMO;
+            }
+        });
+
+        encryption_radio_openpgp.toggled.connect(() => {
+            if (encryption_radio_openpgp.active) {
+                settings.default_encryption = Encryption.PGP;
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Background

Despite Dino claiming _"no unencrypted chats leaving your computer"_ on [its website](https://dino.im/), truth is this only applies to *transport*-level encryption, whereas **end-to-end encryption is disabled by default**, which is a huge privacy risk for users. So far, OMEMO or OpenPGP must be explicitly enabled by the user from the encryption widget below, for each new conversation:

![image](https://user-images.githubusercontent.com/25252461/168476092-4f7fa9ea-a1e5-477c-9af0-a97369ecc658.png)

Several attempts at solving this issue have already been proposed:
- https://github.com/dino/dino/pull/845
- https://github.com/dino/dino/pull/632
- https://github.com/dino/dino/pull/1035

Unfortunately, all of them were unsuccessful since they preferred OMEMO as the default encryption method, a decision some contributors did not particularly agree with.

## Overview

Therefore, this PR instead prompts the user for a default encryption method, and stores this choice persistently for any new conversations. The first time a user starts a chat, the following modal dialog shows up:

![image](https://user-images.githubusercontent.com/25252461/168476743-908a0b2d-be10-4c5e-a551-b26bed0c942b.png)

### Features

- These settings are persistently stored into the database, and can be changed anytime from the settings menu, as shown below.

![image](https://user-images.githubusercontent.com/25252461/168476667-10130402-cab9-4661-990c-3d298c49a4c2.png)

- The modal dialog above is not shown for public chat rooms, following the same logic as the [encryption button](https://github.com/dino/dino/blob/99c076254abc6e2b03b784732a76a389e5a4f801/main/src/ui/chat_input/encryption_button.vala#L93-L102), or when a default encryption method has been already selected.
- Previous encryption settings for each conversation are respected.
     - In order not to break existing behaviour, this means unencrypted chats are left as such, and the dialog above will only appear for new conversations.

## Additional notes

- Neutrality over the decision to pick OpenPGP or OMEMO as the default encryption method has been respected as much as possible for this PR. Unfortunately, GTK automatically activates one of the `RadioButton`s that are shown on the modal dialog, so it inevitably had to be one of them (of course, unencrypted cannot be the default option).
    - As for the settings menu, "Ask" is selected by default, so the modal dialog above appears when the user starts a new conversation.
- As opposed to the settings menu, XEP numbers for OMEMO and OpenPGP have been referenced on the modal dialog so users can search them in order to get a more informed decision.
- `Encryption.parse` was not in fact required (plain `int` could have been stored into the database instead of `string`), but makes it more readable when inspecting the database.

I hope this PR finally solves this issue, so users can enjoy end-to-end encrypted chats by default!