### PR TITLE
Make the main window adaptive with libadwaita

### DIFF
--- a/cmake/FindAdwaita.cmake
+++ b/cmake/FindAdwaita.cmake
@@ -1,0 +1,11 @@
+include(PkgConfigWithFallback)
+find_pkg_config_with_fallback(Adwaita
+    PKG_CONFIG_NAME libadwaita-1
+    LIB_NAMES libadwaita-1
+    INCLUDE_NAMES adwaita.h
+    )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Adwaita
+    REQUIRED_VARS Adwaita_LIBRARY
+    VERSION_VAR Adwaita_VERSION)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -11,6 +11,7 @@ find_packages(MAIN_PACKAGES REQUIRED
     GObject
     GTK4
     ICU
+    Adwaita
 )
 
 set(RESOURCE_LIST

--- a/main/data/conversation_list_titlebar_csd.ui
+++ b/main/data/conversation_list_titlebar_csd.ui
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <requires lib="gtk" version="4.0"/>
-    <object class="GtkHeaderBar" id="header_bar">
+    <requires lib="adw" version="1.0"/>
+    <object class="AdwHeaderBar" id="header_bar">
         <property name="hexpand">False</property>
         <style>
             <class name="dino-left"/>

--- a/main/data/theme.css
+++ b/main/data/theme.css
@@ -4,7 +4,9 @@
  */
 
 window.dino-main .dino-header-right {
-    background: @theme_base_color;
+    background: @insensitive_bg_color;
+    margin-top: 6px;
+    margin-bottom: 6px;
 }
 
 window.dino-main .dino-header-left {

--- a/main/data/unified_main_content.ui
+++ b/main/data/unified_main_content.ui
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <requires lib="gtk" version="4.0"/>
-    <object class="GtkPaned" id="paned">
-        <property name="shrink-start-child">False</property>
-        <property name="shrink-end-child">False</property>
-        <property name="resize-start-child">False</property>
-        <property name="position">300</property>
+    <object class="AdwLeaflet" id="leaflet">
+        <property name="transition-type">slide</property>
+        <property name="can-navigate-back">true</property>
+        <property name="can-navigate-forward">true</property>
         <child>
             <object class="GtkBox" id="left_box">
                 <property name="orientation">vertical</property>

--- a/main/data/unified_main_content.ui
+++ b/main/data/unified_main_content.ui
@@ -7,68 +7,22 @@
         <property name="resize-start-child">False</property>
         <property name="position">300</property>
         <child>
-            <object class="GtkStack" id="left_stack">
+            <object class="GtkBox" id="left_box">
+                <property name="orientation">vertical</property>
                 <child>
-                    <object class="GtkStackPage">
-                        <property name="name">content</property>
-                        <property name="child">
-                            <object class="GtkScrolledWindow">
-                                <property name="hscrollbar_policy">never</property>
-                                <child>
-                                    <object class="DinoUiConversationSelector" id="conversation_list">
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkStackPage">
-                        <property name="name">placeholder</property>
-                        <property name="child">
-                            <object class="GtkBox">
-                                <property name="margin-start">20</property>
-                                <property name="margin-end">20</property>
-                                <property name="margin-top">20</property>
-                                <property name="margin-bottom">20</property>
-                                <property name="spacing">10</property>
-                                <property name="valign">start</property>
-                                <property name="halign">start</property>
-                                <child>
-                                    <object class="GtkImage" id="conversation_list_placeholder_image">
-                                        <property name="valign">start</property>
-                                        <style>
-                                            <class name="dim-label"/>
-                                        </style>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkLabel">
-                                        <property name="wrap">1</property>
-                                        <property name="margin-top">70</property>
-                                        <property name="margin-end">50</property>
-                                        <property name="valign">end</property>
-                                        <property name="label" translatable="1">Click here to start a conversation or join a channel.</property>
-                                        <style>
-                                            <class name="dim-label"/>
-                                        </style>
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
-                    </object>
-                </child>
-            </object>
-        </child>
-        <child>
-            <object class="GtkOverlay">
-                <property name="child">
-                    <object class="GtkStack" id="right_stack">
+                    <object class="GtkStack" id="left_stack">
+                        <property name="hexpand">False</property>
                         <child>
                             <object class="GtkStackPage">
                                 <property name="name">content</property>
                                 <property name="child">
-                                    <object class="DinoUiConversationView" id="conversation_view">
+                                    <object class="GtkScrolledWindow">
+                                        <property name="hscrollbar_policy">never</property>
+                                        <property name="vexpand">1</property>
+                                        <child>
+                                            <object class="DinoUiConversationSelector" id="conversation_list">
+                                            </object>
+                                        </child>
                                     </object>
                                 </property>
                             </object>
@@ -78,16 +32,17 @@
                                 <property name="name">placeholder</property>
                                 <property name="child">
                                     <object class="GtkBox">
-                                        <property name="orientation">vertical</property>
-                                        <property name="hexpand">1</property>
-                                        <property name="vexpand">1</property>
-                                        <property name="halign">center</property>
-                                        <property name="valign">center</property>
+                                        <property name="margin-start">20</property>
+                                        <property name="margin-end">20</property>
+                                        <property name="margin-top">20</property>
+                                        <property name="margin-bottom">20</property>
+                                        <property name="spacing">10</property>
+                                        <property name="valign">start</property>
+                                        <property name="halign">start</property>
+                                        <property name="width_request">260</property>
                                         <child>
-                                            <object class="GtkImage">
-                                                <property name="icon-name">im.dino.Dino-symbolic</property>
-                                                <property name="pixel-size">144</property>
-                                                <property name="margin-bottom">30</property>
+                                            <object class="GtkImage" id="conversation_list_placeholder_image">
+                                                <property name="valign">start</property>
                                                 <style>
                                                     <class name="dim-label"/>
                                                 </style>
@@ -95,13 +50,16 @@
                                         </child>
                                         <child>
                                             <object class="GtkLabel">
-                                                <property name="label" translatable="1">You have no open chats</property>
+                                                <property name="wrap">1</property>
+                                                <property name="margin-top">70</property>
+                                                <property name="margin-end">50</property>
+                                                <property name="xalign">0</property>
+                                                <property name="valign">end</property>
+                                                <property name="max-width-chars">0</property>
+                                                <property name="label" translatable="1">Click here to start a conversation or join a channel.</property>
                                                 <style>
                                                     <class name="dim-label"/>
                                                 </style>
-                                                <attributes>
-                                                    <attribute name="scale" value="1.2"></attribute>
-                                                </attributes>
                                             </object>
                                         </child>
                                     </object>
@@ -109,19 +67,76 @@
                             </object>
                         </child>
                     </object>
-                </property>
-                <child type="overlay">
-                    <object class="GtkRevealer" id="search_revealer">
-                        <property name="halign">end</property>
-                        <property name="transition-type">slide-left</property>
-                        <style>
-                            <class name="dino-sidebar"/>
-                        </style>
+                </child>
+            </object>
+        </child>
+        <child>
+            <object class="GtkBox" id="right_box">
+                <property name="orientation">vertical</property>
+                <child>
+                    <object class="GtkOverlay">
                         <property name="child">
-                            <object class="GtkFrame" id="search_frame">
-                                <property name="width-request">400</property>
+                            <object class="GtkStack" id="right_stack">
+                                <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">content</property>
+                                        <property name="child">
+                                            <object class="DinoUiConversationView" id="conversation_view">
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkStackPage">
+                                        <property name="name">placeholder</property>
+                                        <property name="child">
+                                            <object class="GtkBox">
+                                                <property name="orientation">vertical</property>
+                                                <property name="hexpand">1</property>
+                                                <property name="vexpand">1</property>
+                                                <property name="halign">center</property>
+                                                <property name="valign">center</property>
+                                                <child>
+                                                    <object class="GtkImage">
+                                                        <property name="icon-name">im.dino.Dino-symbolic</property>
+                                                        <property name="pixel-size">144</property>
+                                                        <property name="margin-bottom">30</property>
+                                                        <style>
+                                                            <class name="dim-label"/>
+                                                        </style>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkLabel">
+                                                        <property name="label" translatable="1">You have no open chats</property>
+                                                        <style>
+                                                            <class name="dim-label"/>
+                                                        </style>
+                                                        <attributes>
+                                                            <attribute name="scale" value="1.2"></attribute>
+                                                        </attributes>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </property>
+                                    </object>
+                                </child>
                             </object>
                         </property>
+                        <child type="overlay">
+                            <object class="GtkRevealer" id="search_revealer">
+                                <property name="halign">end</property>
+                                <property name="transition-type">slide-left</property>
+                                <style>
+                                    <class name="dino-sidebar"/>
+                                </style>
+                                <property name="child">
+                                    <object class="GtkFrame" id="search_frame">
+                                        <property name="width-request">400</property>
+                                    </object>
+                                </property>
+                            </object>
+                        </child>
                     </object>
                 </child>
             </object>

--- a/main/data/unified_window_placeholder.ui
+++ b/main/data/unified_window_placeholder.ui
@@ -2,13 +2,19 @@
 <interface>
     <requires lib="gtk" version="4.0"/>
     <template class="DinoUiMainWindowPlaceholder">
-        <property name="valign">center</property>
+        <property name="valign">fill</property>
         <child>
             <object class="GtkBox" id="box">
                 <property name="orientation">vertical</property>
-                <property name="valign">center</property>
-                <property name="halign">center</property>
+                <property name="valign">fill</property>
+                <property name="halign">fill</property>
                 <property name="hexpand">1</property>
+                <property name="vexpand">1</property>
+                <child>
+                    <object class="GtkHeaderBar">
+                        <property name="show-title-buttons">true</property>
+                    </object>
+                </child>
                 <child>
                     <object class="GtkImage">
                         <property name="icon-name">im.dino.Dino-symbolic</property>

--- a/main/src/ui/application.vala
+++ b/main/src/ui/application.vala
@@ -4,7 +4,7 @@ using Dino.Entities;
 using Dino.Ui;
 using Xmpp;
 
-public class Dino.Ui.Application : Gtk.Application, Dino.Application {
+public class Dino.Ui.Application : Adw.Application, Dino.Application {
     private const string[] KEY_COMBINATION_QUIT = {"<Ctrl>Q", null};
     private const string[] KEY_COMBINATION_ADD_CHAT = {"<Ctrl>T", null};
     private const string[] KEY_COMBINATION_ADD_CONFERENCE = {"<Ctrl>G", null};
@@ -272,25 +272,24 @@ public class Dino.Ui.Application : Gtk.Application, Dino.Application {
                 case "0.3": version = @"$version - <span font_style='italic'>Theikenmeer</span>"; break;
             }
         }
-        Gtk.AboutDialog dialog = new Gtk.AboutDialog();
-        dialog.destroy_with_parent = true;
-        dialog.transient_for = window;
-        dialog.modal = true;
-        dialog.title = _("About Dino");
+        Adw.AboutWindow about = new Adw.AboutWindow();
+        about.destroy_with_parent = true;
+        about.transient_for = window;
+        about.modal = true;
+        about.title = _("About Dino");
 
-        dialog.logo_icon_name = "im.dino.Dino";
-        dialog.program_name = "Dino";
-        dialog.version = version;
-        dialog.comments = "Dino. Communicating happiness.";
-        dialog.website = "https://dino.im/";
-        dialog.website_label = "dino.im";
-        dialog.copyright = "Copyright © 2016-2022 - Dino Team";
-        dialog.license_type = License.GPL_3_0;
+        about.application_icon = "im.dino.Dino";
+        about.application_name = "Dino";
+        about.version = version;
+        about.comments = "Dino. Communicating happiness.";
+        about.website = "https://dino.im/";
+        about.copyright = "Copyright © 2016-2022 - Dino Team";
+        about.license_type = License.GPL_3_0;
 
         if (!use_csd()) {
-            dialog.set_titlebar(null);
+            about.set_titlebar(null);
         }
-        dialog.present();
+        about.present();
     }
 
     private void show_join_muc_dialog(Account? account, string jid) {

--- a/main/src/ui/conversation_content_view/message_widget.vala
+++ b/main/src/ui/conversation_content_view/message_widget.vala
@@ -28,7 +28,7 @@ public class MessageMetaItem : ContentMetaItem {
     ulong style_updated_id = -1;
     ulong marked_notify_handler_id = -1;
 
-    public Label label = new Label("") { use_markup=true, xalign=0, selectable=true, wrap=true, wrap_mode=Pango.WrapMode.WORD_CHAR, hexpand=true, vexpand=true };
+    public Label label = new Label("") { use_markup=true, xalign=0, selectable=false, wrap=true, wrap_mode=Pango.WrapMode.WORD_CHAR, hexpand=true, vexpand=true };
 
     public MessageMetaItem(ContentItem content_item, StreamInteractor stream_interactor) {
         base(content_item);

--- a/main/src/ui/conversation_list_titlebar.vala
+++ b/main/src/ui/conversation_list_titlebar.vala
@@ -15,12 +15,12 @@ public class ConversationListTitlebar : Gtk.Box {
     }
 }
 
-public static HeaderBar get_conversation_list_titlebar_csd() {
+public static Adw.HeaderBar get_conversation_list_titlebar_csd() {
     Builder builder = new Builder.from_resource("/im/dino/Dino/conversation_list_titlebar_csd.ui");
     MenuButton add_button = (MenuButton) builder.get_object("add_button");
     MenuButton menu_button = (MenuButton) builder.get_object("menu_button");
     create_add_menu(add_button, menu_button);
-    return (HeaderBar) builder.get_object("header_bar");
+    return (Adw.HeaderBar) builder.get_object("header_bar");
 }
 
 private static void create_add_menu(MenuButton add_button, MenuButton menu_button) {

--- a/main/src/ui/conversation_titlebar/conversation_titlebar.vala
+++ b/main/src/ui/conversation_titlebar/conversation_titlebar.vala
@@ -68,7 +68,7 @@ public class ConversationTitlebarCsd : ConversationTitlebar, Object {
     public new string? title { get { return title_label.label; } set { title_label.label = value; } }
     public new string? subtitle { get { return subtitle_label.label; } set { subtitle_label.label = value; subtitle_label.visible = (value != null); } }
 
-    public HeaderBar header_bar = new HeaderBar();
+    public Adw.HeaderBar header_bar = new Adw.HeaderBar();
     private Label title_label = new Label("") { ellipsize=EllipsizeMode.END };
     private Label subtitle_label = new Label("") { ellipsize=EllipsizeMode.END, visible=false };
 

--- a/main/src/ui/conversation_titlebar/conversation_titlebar.vala
+++ b/main/src/ui/conversation_titlebar/conversation_titlebar.vala
@@ -12,6 +12,9 @@ public interface ConversationTitlebar : Object {
 
     public abstract void insert_button(Widget button);
     public abstract Widget get_widget();
+
+    public abstract bool back_button_visible{ get; set; }
+    public signal void back_pressed();
 }
 
 public class ConversationTitlebarNoCsd : ConversationTitlebar, Object {
@@ -31,13 +34,26 @@ public class ConversationTitlebarNoCsd : ConversationTitlebar, Object {
         }
     }
 
+    public bool back_button_visible {
+        get { return back_revealer.reveal_child; }
+        set { back_revealer.reveal_child = value; }
+    }
+
     private Box widgets_box = new Box(Orientation.HORIZONTAL, 7) { margin_start=15, valign=Align.END };
     private Label title_label = new Label("") { ellipsize=EllipsizeMode.END };
     private Label subtitle_label = new Label("") { use_markup=true, ellipsize=EllipsizeMode.END, visible=false };
+    private Revealer back_revealer;
 
     construct {
         Box content_box = new Box(Orientation.HORIZONTAL, 0) { margin_start=15, margin_end=10, hexpand=true };
         main.append(content_box);
+
+        back_revealer = new Revealer() { visible = true, transition_type = RevealerTransitionType.SLIDE_RIGHT, transition_duration = 200, can_focus = false, reveal_child = false };
+        Button back_button = new Button.from_icon_name("go-previous-symbolic") { visible = true, valign = Align.CENTER, use_underline = true };
+        back_button.get_style_context().add_class("image-button");
+        back_button.clicked.connect(() => back_pressed());
+        back_revealer.set_child(back_button);
+        content_box.append(back_revealer);
 
         Box titles_box = new Box(Orientation.VERTICAL, 0) { valign=Align.CENTER, hexpand=true };
         content_box.append(titles_box);
@@ -67,10 +83,15 @@ public class ConversationTitlebarCsd : ConversationTitlebar, Object {
 
     public new string? title { get { return title_label.label; } set { title_label.label = value; } }
     public new string? subtitle { get { return subtitle_label.label; } set { subtitle_label.label = value; subtitle_label.visible = (value != null); } }
+    public bool back_button_visible {
+        get { return back_revealer.reveal_child; }
+        set { back_revealer.reveal_child = value; }
+    }
 
     public Adw.HeaderBar header_bar = new Adw.HeaderBar();
     private Label title_label = new Label("") { ellipsize=EllipsizeMode.END };
     private Label subtitle_label = new Label("") { ellipsize=EllipsizeMode.END, visible=false };
+    private Revealer back_revealer;
 
     public ConversationTitlebarCsd() {
         Box titles_box = new Box(Orientation.VERTICAL, 0) { valign=Align.CENTER };
@@ -81,6 +102,13 @@ public class ConversationTitlebarCsd : ConversationTitlebar, Object {
         subtitle_label.attributes.insert(Pango.attr_scale_new(Pango.Scale.SMALL));
         subtitle_label.add_css_class("dim-label");
         titles_box.append(subtitle_label);
+
+        back_revealer = new Revealer() { visible = true, transition_type = RevealerTransitionType.SLIDE_RIGHT, transition_duration = 200, can_focus = false, reveal_child = false };
+        Button back_button = new Button.from_icon_name("go-previous-symbolic") { visible = true, valign = Align.CENTER, use_underline = true };
+        back_button.get_style_context().add_class("image-button");
+        back_button.clicked.connect(() => back_pressed());
+        back_revealer.set_child(back_button);
+        header_bar.pack_start(back_revealer);
 
         header_bar.set_title_widget(titles_box);
     }

--- a/main/src/ui/main_window.vala
+++ b/main/src/ui/main_window.vala
@@ -20,7 +20,7 @@ public class MainWindow : Adw.Window {
     public ConversationTitlebar conversation_titlebar;
     public Widget conversation_list_titlebar;
     public Box box = new Box(Orientation.VERTICAL, 0) { orientation=Orientation.VERTICAL };
-    public Paned paned;
+    public Adw.Leaflet leaflet;
     public Box left_box;
     public Box right_box;
     public Revealer search_revealer;
@@ -60,8 +60,8 @@ public class MainWindow : Adw.Window {
 
     private void setup_unified() {
         Builder builder = new Builder.from_resource("/im/dino/Dino/unified_main_content.ui");
-        paned = (Paned) builder.get_object("paned");
-        box.append(paned);
+        leaflet = (Adw.Leaflet) builder.get_object("leaflet");
+        box.append(leaflet);
         left_box = (Box) builder.get_object("left_box");
         right_box = (Box) builder.get_object("right_box");
         left_stack = (Stack) builder.get_object("left_stack");
@@ -69,6 +69,7 @@ public class MainWindow : Adw.Window {
         conversation_view = (ConversationView) builder.get_object("conversation_view");
         search_revealer = (Revealer) builder.get_object("search_revealer");
         conversation_selector = ((ConversationSelector) builder.get_object("conversation_list")).init(stream_interactor);
+        conversation_selector.conversation_selected.connect_after(() => leaflet.navigate(Adw.NavigationDirection.FORWARD));
 
         Frame search_frame = (Frame) builder.get_object("search_frame");
         global_search = new GlobalSearch(stream_interactor);
@@ -82,8 +83,8 @@ public class MainWindow : Adw.Window {
         if (Util.use_csd()) {
             conversation_list_titlebar = get_conversation_list_titlebar_csd();
             conversation_titlebar = new ConversationTitlebarCsd();
-            paned.bind_property("folded", conversation_list_titlebar, "show-end-title-buttons", BindingFlags.SYNC_CREATE);
-            paned.bind_property("folded", conversation_titlebar.get_widget(), "show-start-title-buttons", BindingFlags.SYNC_CREATE);
+            leaflet.bind_property("folded", conversation_list_titlebar, "show-end-title-buttons", BindingFlags.SYNC_CREATE);
+            leaflet.bind_property("folded", conversation_titlebar.get_widget(), "show-start-title-buttons", BindingFlags.SYNC_CREATE);
         } else {
             Label title_label = new Label("Dino");
             HeaderBar titlebar = new HeaderBar() { title_widget=title_label, show_title_buttons=true };
@@ -94,6 +95,8 @@ public class MainWindow : Adw.Window {
         }
         left_box.prepend(conversation_list_titlebar);
         right_box.prepend(conversation_titlebar.get_widget());
+        leaflet.notify["folded"].connect_after(() => conversation_titlebar.back_button_visible = leaflet.folded);
+        conversation_titlebar.back_pressed.connect(() => leaflet.navigate(Adw.NavigationDirection.BACK));
     }
 
     private void setup_stack() {

--- a/main/src/ui/main_window.vala
+++ b/main/src/ui/main_window.vala
@@ -51,8 +51,6 @@ public class MainWindow : Adw.Window {
 
         this.add_css_class("dino-main");
 
-        Gtk.Settings.get_default().notify["gtk-decoration-layout"].connect(set_window_buttons);
-        ((Widget)this).realize.connect(set_window_buttons);
         ((Widget)this).realize.connect(restore_window_size);
 
         setup_unified();
@@ -96,18 +94,6 @@ public class MainWindow : Adw.Window {
         }
         left_box.prepend(conversation_list_titlebar);
         right_box.prepend(conversation_titlebar.get_widget());
-    }
-
-    private void set_window_buttons() {
-        if (!Util.use_csd()) return;
-        Gtk.Settings? gtk_settings = Gtk.Settings.get_default();
-        if (gtk_settings == null) return;
-
-        string[] buttons = gtk_settings.gtk_decoration_layout.split(":");
-        HeaderBar conversation_headerbar = this.conversation_titlebar.get_widget() as HeaderBar;
-        conversation_headerbar.decoration_layout = ((buttons.length == 2) ? ":" + buttons[1] : "");
-        HeaderBar conversation_list_headerbar = this.conversation_list_titlebar as HeaderBar;
-        conversation_list_headerbar.decoration_layout = buttons[0] + ":";
     }
 
     private void setup_stack() {

--- a/main/src/ui/main_window.vala
+++ b/main/src/ui/main_window.vala
@@ -84,6 +84,8 @@ public class MainWindow : Adw.Window {
         if (Util.use_csd()) {
             conversation_list_titlebar = get_conversation_list_titlebar_csd();
             conversation_titlebar = new ConversationTitlebarCsd();
+            paned.bind_property("folded", conversation_list_titlebar, "show-end-title-buttons", BindingFlags.SYNC_CREATE);
+            paned.bind_property("folded", conversation_titlebar.get_widget(), "show-start-title-buttons", BindingFlags.SYNC_CREATE);
         } else {
             Label title_label = new Label("Dino");
             HeaderBar titlebar = new HeaderBar() { title_widget=title_label, show_title_buttons=true };


### PR DESCRIPTION
Changes the Gtk.Paned widget in the main window to Adw.Leaflet from libadwaita. Fixes #1182.

Uses Adw.Application and a HeaderBarless Adw.Window for the main window. Changes the layout to two columns / vertical boxes with a single leaflet wigdet and two header bars (or title bars in the NonCSD version).

Adds a back button to the ConversationTitlebar interface and implements it in the concrete classes.

Also makes the about dialog into Adw.AboutWindow.

This is a step towards solving #178.