### PR TITLE
Replace xmpp uris with the name of the person if they're in your roster

### DIFF
--- a/libdino/src/entity/settings.vala
+++ b/libdino/src/entity/settings.vala
@@ -12,6 +12,7 @@ public class Settings : Object {
         notifications_ = col_to_bool_or_default("notifications", true);
         convert_utf8_smileys_ = col_to_bool_or_default("convert_utf8_smileys", true);
         check_spelling = col_to_bool_or_default("check_spelling", true);
+        replace_xmpp_uris = col_to_bool_or_default("replace_xmpp_uris", true);
     }
 
     private bool col_to_bool_or_default(string key, bool def) {
@@ -76,6 +77,18 @@ public class Settings : Object {
                 .value(db.settings.value, value.to_string())
                 .perform();
             check_spelling_ = value;
+        }
+    }
+
+    private bool replace_xmpp_uris_;
+    public bool replace_xmpp_uris {
+        get { return replace_xmpp_uris_; }
+        set {
+            db.settings.upsert()
+                .value(db.settings.key, "replace_xmpp_uris", true)
+                .value(db.settings.value, value.to_string())
+                .perform();
+            replace_xmpp_uris_ = value;
         }
     }
 }

--- a/main/data/settings_dialog.ui
+++ b/main/data/settings_dialog.ui
@@ -63,6 +63,15 @@
                                 </layout>
                             </object>
                         </child>
+                        <child>
+                            <object class="GtkCheckButton" id="replace_xmpp_uris_checkbutton">
+                                <property name="label" translatable="yes">Replace XMPP URIs with names</property>
+                                <layout>
+                                    <property name="column">0</property>
+                                    <property name="row">5</property>
+                                </layout>
+                            </object>
+                        </child>
                     </object>
                 </child>
             </object>

--- a/main/src/ui/settings_dialog.vala
+++ b/main/src/ui/settings_dialog.vala
@@ -10,6 +10,7 @@ class SettingsDialog : Dialog {
     [GtkChild] private unowned CheckButton notification_checkbutton;
     [GtkChild] private unowned CheckButton emoji_checkbutton;
     [GtkChild] private unowned CheckButton check_spelling_checkbutton;
+    [GtkChild] private unowned CheckButton replace_xmpp_uris_checkbutton;
 
     Dino.Entities.Settings settings = Dino.Application.get_default().settings;
 
@@ -21,12 +22,14 @@ class SettingsDialog : Dialog {
         notification_checkbutton.active = settings.notifications;
         emoji_checkbutton.active = settings.convert_utf8_smileys;
         check_spelling_checkbutton.active = settings.check_spelling;
+        replace_xmpp_uris_checkbutton.active = settings.replace_xmpp_uris;
 
         typing_checkbutton.toggled.connect(() => { settings.send_typing = typing_checkbutton.active; } );
         marker_checkbutton.toggled.connect(() => { settings.send_marker = marker_checkbutton.active; } );
         notification_checkbutton.toggled.connect(() => { settings.notifications = notification_checkbutton.active; } );
         emoji_checkbutton.toggled.connect(() => { settings.convert_utf8_smileys = emoji_checkbutton.active; });
         check_spelling_checkbutton.toggled.connect(() => { settings.check_spelling = check_spelling_checkbutton.active; });
+        replace_xmpp_uris_checkbutton.toggled.connect(() => { settings.replace_xmpp_uris = replace_xmpp_uris_checkbutton.active; });
     }
 }
 

--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -307,7 +307,8 @@ public static string parse_add_markup_theme(string s_, string? highlight_word, b
                 }
 
                 string? text = link;
-                if (link[0:5] == "xmpp:" && true) {
+                Dino.Entities.Settings settings = Dino.Application.get_default().settings;
+                if (link[0:5] == "xmpp:" && settings.replace_xmpp_uris) {
                     // lookup name for XMPP uri
                     // SELECT name FROM roster WHERE jid = %s
                     Database db = Dino.Application.get_default().db;

--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -2,6 +2,7 @@ using Gee;
 using Gtk;
 
 using Dino.Entities;
+using Qlite;
 using Xmpp;
 
 namespace Dino.Ui.Util {
@@ -305,9 +306,21 @@ public static string parse_add_markup_theme(string s_, string? highlight_word, b
                     }
                 }
 
+                string? text = link;
+                if (link[0:5] == "xmpp:" && true) {
+                    // lookup name for XMPP uri
+                    // SELECT name FROM roster WHERE jid = %s
+                    Database db = Dino.Application.get_default().db;
+                    RowOption row = db.roster.select({db.roster.handle}).with(db.roster.jid, "=", link[5:]).single().row();
+                    if (row.is_present()) {
+                        if(row[db.roster.handle] != null) {
+                            text = row[db.roster.handle];
+                        }
+                    }
+                }
                 return parse_add_markup_theme(s[0:start], highlight_word, parse_links, parse_text_markup, false, dark_theme, ref theme_dependent, already_escaped) +
                         "<a href=\"" + Markup.escape_text(link) + "\">" +
-                        parse_add_markup_theme(link, highlight_word, false, false, false, dark_theme, ref theme_dependent, already_escaped) +
+                        parse_add_markup_theme(text, highlight_word, false, false, false, dark_theme, ref theme_dependent, already_escaped) +
                         "</a>" +
                         parse_add_markup_theme(s[end:s.length], highlight_word, parse_links, parse_text_markup, false, dark_theme, ref theme_dependent, already_escaped);
             }


### PR DESCRIPTION
This is especially useful for users of Cheogram/JMP.chat for group MMSs, so you can know who is talking to you without having to memorize their cell numbers.

![before](https://user-images.githubusercontent.com/12452738/192939250-ccc39f59-93c7-497f-97a7-b744873734ba.png)

![after](https://user-images.githubusercontent.com/12452738/192939247-be63046e-933f-44bf-a3bd-04db109262d3.png)

