### PR TITLE
Allow Starting Conversation with JID Without Localpart

### DIFF
--- a/main/src/ui/add_conversation/select_jid_fragment.vala
+++ b/main/src/ui/add_conversation/select_jid_fragment.vala
@@ -62,7 +62,7 @@ public class SelectJidFragment : Gtk.Box {
 
         try {
             Jid parsed_jid = new Jid(str);
-            if (parsed_jid != null && parsed_jid.localpart != null) {
+            if (parsed_jid != null) {
                 foreach (Account account in accounts) {
                     var list_row = new Gtk.ListBoxRow();
                     list_row.set_child(new AddListRow(stream_interactor, parsed_jid, account));


### PR DESCRIPTION
Even though it's rare, it is possible for a JID to not have a localpart, especially components.

We should still be able to start conversations with this JID, though, without having to resort to another client.

That having been said, there may be a reason this was specifically excluded, so let me know if there's more stuff you'd like me to add to make this acceptable!

## Before
![image](https://user-images.githubusercontent.com/12766/199597681-f82fe78f-d16a-4ac9-94a5-aff88a815eaf.png)

## After
![image](https://user-images.githubusercontent.com/12766/199597714-42b3dc52-c9b8-420f-80a5-2b5588d9b520.png)
