### PR TITLE
Parse conference.password from XEP-0402 bookmarks

### DIFF
--- a/xmpp-vala/src/module/xep/0402_bookmarks2.vala
+++ b/xmpp-vala/src/module/xep/0402_bookmarks2.vala
@@ -105,6 +105,7 @@ public class Module : BookmarksProvider, XmppStreamModule {
         conference.name = conference_node.get_attribute("name", NS_URI);
         conference.autojoin = conference_node.get_attribute_bool("autojoin", false, NS_URI);
         conference.nick = conference_node.get_deep_string_content("nick");
+        conference.password = conference_node.get_deep_string_content("password");
         return conference;
     }
 


### PR DESCRIPTION
The conference password was not parsed from XEP-0402 responses. This caused autojoin to password protected group chats to fail, and when joining manually, the password had to be typed in every time.

Probably helps with #1293.