### PR TITLE
Pin on click

### DIFF
--- a/libdino/src/entity/conversation.vala
+++ b/libdino/src/entity/conversation.vala
@@ -227,7 +227,6 @@ public class Conversation : Object {
             case "send-marker":
                 update.set(db.conversation.send_marker, send_marker); break;
             case "pinned":
-                print("auto-update %d %d %d\n", id, pinned, 0);
                 update.set(db.conversation.pinned, pinned); break;
         }
         update.perform();

--- a/main/src/ui/contact_details/settings_provider.vala
+++ b/main/src/ui/contact_details/settings_provider.vala
@@ -54,7 +54,7 @@ public class SettingsProvider : Plugins.ContactDetailsProvider, Object {
         string category = conversation.type_ == Conversation.Type.GROUPCHAT ? DETAILS_HEADLINE_ROOM : DETAILS_HEADLINE_CHAT;
         contact_details.add(category, _("Pin conversation"), _("Pins the conversation to the top of the conversation list"), pinned_switch);
         pinned_switch.state = conversation.pinned != 0;
-        pinned_switch.state_set.connect((state) => { conversation.pinned = state ? 1 : 0; return false; });
+        pinned_switch.state_set.connect((state) => { if (state) conversation.pin(); else conversation.unpin(); return false; });
     }
 
     private Conversation.Setting get_setting(string id) {

--- a/main/src/ui/conversation_selector/conversation_selector.vala
+++ b/main/src/ui/conversation_selector/conversation_selector.vala
@@ -40,6 +40,7 @@ public class ConversationSelector : Widget {
         add_css_class("sidebar");
         list_box.set_header_func(header);
         list_box.set_sort_func(sort);
+        list_box.set_activate_on_single_click(false);
 
         realize.connect(() => {
             ListBoxRow? first_row = list_box.get_row_at_index(0);
@@ -49,12 +50,23 @@ public class ConversationSelector : Widget {
         });
 
         list_box.row_selected.connect(row_selected);
+        list_box.row_activated.connect(row_activated);
     }
 
     public void row_selected(ListBoxRow? r) {
         ConversationSelectorRow? row = r as ConversationSelectorRow;
         if (row != null) {
             conversation_selected(row.conversation);
+        }
+    }
+
+    public void row_activated(ListBoxRow r) {
+        ConversationSelectorRow? row = r as ConversationSelectorRow;
+        Conversation c = row.conversation;
+        if (c.pinned != 0) {
+            c.unpin();
+        } else {
+            c.pin();
         }
     }
 

--- a/main/src/ui/conversation_selector/conversation_selector.vala
+++ b/main/src/ui/conversation_selector/conversation_selector.vala
@@ -45,14 +45,13 @@ public class ConversationSelector : Widget {
             ListBoxRow? first_row = list_box.get_row_at_index(0);
             if (first_row != null) {
                 list_box.select_row(first_row);
-                row_activated(first_row);
             }
         });
 
-        list_box.row_activated.connect(row_activated);
+        list_box.row_selected.connect(row_selected);
     }
 
-    public void row_activated(ListBoxRow r) {
+    public void row_selected(ListBoxRow? r) {
         ConversationSelectorRow? row = r as ConversationSelectorRow;
         if (row != null) {
             conversation_selected(row.conversation);
@@ -113,7 +112,6 @@ public class ConversationSelector : Widget {
             }
             if (next_select_row != null) {
                 list_box.select_row(next_select_row);
-                row_activated(next_select_row);
             }
         }
     }
@@ -135,7 +133,6 @@ public class ConversationSelector : Widget {
         ListBoxRow? next_select_row = list_box.get_row_at_index(new_index);
         if (next_select_row != null) {
             list_box.select_row(next_select_row);
-            row_activated(next_select_row);
         }
     }
 


### PR DESCRIPTION
I've added ability to pin chats directly from conversation list.
This involves several changes in application logic:
- Change signal used to select conversation.
`GtkListBox` have separate signals to select and activate rows, 
so, from semantics's perspective,  `row_selected` is more correct way to choose chat.
- Add pin logic to conversations themselves. 
First `pinned` is no more assumed as boolean value now, pin order matter. 
This allows to add option to rearrange pin in future.
I agree that it done in kinda messy way, but i did not found way to do it more correctly. If you can suggest, I'm  ready to fix it
- Change all external pin logic to call `pin` and `unpin` functions. This is simply point of this PR :)

 