### PR TITLE
Always export symbols to fix startup on BSDs

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -232,6 +232,7 @@ add_executable(dino ${MAIN_VALA_C} ${MAIN_GRESOURCES_TARGET})
 add_dependencies(dino ${GETTEXT_PACKAGE}-translations)
 target_include_directories(dino PRIVATE src)
 target_link_libraries(dino libdino ${MAIN_PACKAGES})
+set_target_properties(dino PROPERTIES ENABLE_EXPORTS TRUE)
 
 if(WIN32)
     target_link_libraries(dino -mwindows)


### PR DESCRIPTION
```
$ dino
(dino:38515): Gtk-ERROR **: 15:38:38.538: failed to add UI from resource /im/dino/Dino/unified_main_content.ui: .:26:1 Invalid object type 'DinoUiConversationSelector'
Trace/BPT trap (core dumped)
```

This works on Linux because CMake itself links with `-rdynamic` by default
as per its `Modules/Platform/Linux-*.cmake`.

OpenBSD carries this as local patch, FreeBSD links with `--export-dynamics`.
Just linking with `-rdynamic` also fixes it on OpenBSD, as expected.

https://cmake.org/cmake/help/latest/prop_tgt/ENABLE_EXPORTS.html

Fix #438.
