### PR TITLE
[GTK4] User-selectable default encryption settings

### DIFF
--- a/libdino/src/entity/conversation.vala
+++ b/libdino/src/entity/conversation.vala
@@ -33,7 +33,7 @@ public class Conversation : Object {
             }
         }
     }
-    public Encryption encryption { get; set; default = Encryption.NONE; }
+    public Encryption encryption { get; set; default = Encryption.UNKNOWN; }
     public Message? read_up_to { get; set; }
     public int read_up_to_item { get; set; default=-1; }
 

--- a/libdino/src/entity/encryption.vala
+++ b/libdino/src/entity/encryption.vala
@@ -11,6 +11,27 @@ namespace Dino.Entities {
         public bool is_some() {
             return this != NONE;
         }
+
+        public static Encryption parse(string str) {
+            switch (str) {
+                case "DINO_ENTITIES_ENCRYPTION_NONE":
+                    return NONE;
+                case "DINO_ENTITIES_ENCRYPTION_PGP":
+                    return PGP;
+                case "DINO_ENTITIES_ENCRYPTION_OMEMO":
+                    return OMEMO;
+                case "DINO_ENTITIES_ENCRYPTION_DTLS_SRTP":
+                    return DTLS_SRTP;
+                case "DINO_ENTITIES_ENCRYPTION_SRTP":
+                    return SRTP;
+                case "DINO_ENTITIES_ENCRYPTION_UNKNOWN":
+                    // Fall through.
+                default:
+                    break;
+            }
+
+            return UNKNOWN;
+        }
     }
 
 }

--- a/libdino/src/entity/settings.vala
+++ b/libdino/src/entity/settings.vala
@@ -12,11 +12,18 @@ public class Settings : Object {
         notifications_ = col_to_bool_or_default("notifications", true);
         convert_utf8_smileys_ = col_to_bool_or_default("convert_utf8_smileys", true);
         check_spelling = col_to_bool_or_default("check_spelling", true);
+        default_encryption = col_to_encryption_or_default("default_encryption", Encryption.UNKNOWN);
     }
 
     private bool col_to_bool_or_default(string key, bool def) {
         string? val = db.settings.select({db.settings.value}).with(db.settings.key, "=", key)[db.settings.value];
         return val != null ? bool.parse(val) : def;
+    }
+
+    private Encryption col_to_encryption_or_default(string key, Encryption def) {
+        var sval = db.settings.value;
+        string? val = db.settings.select({sval}).with(db.settings.key, "=", key)[sval];
+        return val != null ? Encryption.parse(val) : def;
     }
 
     private bool send_typing_;
@@ -79,6 +86,20 @@ public class Settings : Object {
             check_spelling_ = value;
         }
     }
+
+    private Encryption default_encryption_;
+    public Encryption default_encryption {
+        get { return default_encryption_; }
+        set {
+            string valstr = value.to_string();
+            db.settings.upsert()
+                .value(db.settings.key, "default_encryption", true)
+                .value(db.settings.value, valstr)
+                .perform();
+            default_encryption_ = value;
+        }
+    }
+
 }
 
 }

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -68,6 +68,7 @@ set(RESOURCE_LIST
     conversation_list_titlebar_csd.ui
     conversation_row.ui
     conversation_view.ui
+    default_encryption_dialog.ui
     file_default_widget.ui
     file_send_overlay.ui
     global_search.ui

--- a/main/data/default_encryption_dialog.ui
+++ b/main/data/default_encryption_dialog.ui
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.6"/>
+  <object class="GtkDialog" id="dialog">
+    <property name="can_focus">True</property>
+    <property name="modal">True</property>
+    <property name="default_width">320</property>
+    <property name="default_height">260</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="default_encryption_warning_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">You are opening a new conversation without having set end-to-end encryption by default.
+
+It is strongly recommended to enable it to prevent your messages from being read by third parties.
+
+Please select an option to start this conversation with. Choosing one of the encryption methods will also set it as default in the global settings.
+</property>
+                <property name="wrap">True</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="omemo">
+                <property name="label" translatable="yes">OMEMO (automatic setup)</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">False</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="openpgp">
+                <property name="label" translatable="yes">OpenPGP (external setup required)</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">False</property>
+                <property name="group">omemo</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="none">
+                <property name="label" translatable="yes">Unencrypted</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">False</property>
+                <property name="group">omemo</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="accept_button">
+                <property name="label" translatable="yes">Apply</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/main/data/gresource.xml
+++ b/main/data/gresource.xml
@@ -16,6 +16,7 @@
     <file>conversation_list_titlebar_csd.ui</file>
     <file>conversation_row.ui</file>
     <file>conversation_view.ui</file>
+    <file>default_encryption_dialog.ui</file>
     <file>dino-conversation-list-placeholder-arrow.svg</file>
     <file>file_default_widget.ui</file>
     <file>file_send_overlay.ui</file>

--- a/main/data/settings_dialog.ui
+++ b/main/data/settings_dialog.ui
@@ -11,6 +11,49 @@
                     <object class="AdwPreferencesGroup">
                         <child>
                             <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Default encryption</property>
+                                <child>
+                                    <object class="GtkBox" id="default_encryption_box">
+                                        <child>
+                                            <object class="GtkCheckButton" id="encryption_radio_undecided">
+                                                <property name="label" translatable="yes">Ask</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="active">False</property>
+                                                <property name="group">encryption_radio_undecided</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkCheckButton" id="encryption_radio_omemo">
+                                                <property name="label" translatable="yes">OMEMO</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="active">False</property>
+                                                <property name="group">encryption_radio_undecided</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkCheckButton" id="encryption_radio_openpgp">
+                                                <property name="label" translatable="yes">OpenPGP</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="active">False</property>
+                                                <property name="group">encryption_radio_undecided</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwPreferencesGroup">
+                        <child>
+                            <object class="AdwActionRow">
                                 <property name="title" translatable="yes">Send _Typing Notifications</property>
                                 <property name="use-underline">True</property>
                                 <property name="activatable-widget">typing_switch</property>

--- a/main/src/ui/chat_input/chat_input_controller.vala
+++ b/main/src/ui/chat_input/chat_input_controller.vala
@@ -104,7 +104,7 @@ public class ChatInputController : Object {
     private void on_encryption_changed(Encryption encryption) {
         reset_input_field_status();
 
-        if (encryption == Encryption.NONE) return;
+        if (encryption == Encryption.NONE || encryption == Encryption.UNKNOWN) return;
 
         Application app = GLib.Application.get_default() as Application;
         var encryption_entry = app.plugin_registry.encryption_list_entries[encryption];

--- a/main/src/ui/conversation_view_controller.vala
+++ b/main/src/ui/conversation_view_controller.vala
@@ -114,6 +114,89 @@ public class ConversationViewController : Object {
         ((Gtk.Window)view.get_root()).add_shortcut(shortcut);
     }
 
+    private void update_conversation_encryption(Conversation? conversation) {
+        if (conversation == null) {
+            return;
+        }
+
+        bool visible = false;
+
+        // FIXME duplicate logic from encryption_button.vala
+        switch (conversation.type_) {
+            case Conversation.Type.CHAT:
+                visible = true;
+                break;
+            case Conversation.Type.GROUPCHAT_PM:
+                visible = false;
+                break;
+            case Conversation.Type.GROUPCHAT:
+                visible = stream_interactor.get_module(MucManager.IDENTITY).is_private_room(conversation.account, conversation.counterpart);
+                break;
+        }
+
+        if (visible && conversation.encryption == UNKNOWN) {
+            Dino.Entities.Settings settings = Dino.Application.get_default().settings;
+
+            if (settings.default_encryption == UNKNOWN) {
+                var selection_dialog_builder = new Builder.from_resource("/im/dino/Dino/default_encryption_dialog.ui");
+                var selection_dialog = selection_dialog_builder.get_object("dialog") as Dialog;
+                var accept_button = selection_dialog_builder.get_object("accept_button") as Button;
+                var omemo_radio = selection_dialog_builder.get_object("omemo") as CheckButton;
+                var openpgp_radio = selection_dialog_builder.get_object("openpgp") as CheckButton;
+                var none_radio = selection_dialog_builder.get_object("none") as CheckButton;
+                Encryption selected_default = UNKNOWN;
+
+                accept_button.sensitive = false;
+
+                omemo_radio.toggled.connect(() => {
+                    accept_button.sensitive = true;
+                });
+
+                openpgp_radio.toggled.connect(() => {
+                    accept_button.sensitive = true;
+                });
+
+                none_radio.toggled.connect(() => {
+                    accept_button.sensitive = true;
+                });
+
+                accept_button.clicked.connect(() => {
+                    if (omemo_radio.active) {selected_default = OMEMO;}
+                    else if (openpgp_radio.active) {selected_default = PGP;}
+                    else if (none_radio.active) {selected_default = NONE;}
+
+                    selection_dialog.response(selected_default);
+                    selection_dialog.close();
+                });
+
+                selection_dialog.response.connect((response_id) => {
+                    if (response_id == Gtk.ResponseType.DELETE_EVENT) {
+                        conversation.encryption = NONE;
+                    }
+                    else {
+                        conversation.encryption = response_id;
+
+                        if (selected_default != NONE) {
+                            settings.default_encryption = response_id;
+                        }
+                        else {
+                            // Set conversation as unencrypted, but keep
+                            // default encryption setting as undecided.
+                        }
+                    }
+                });
+
+                selection_dialog.show();
+            }
+            else {
+                conversation.encryption = settings.default_encryption;
+            }
+        }
+        else if (!visible) {
+            conversation.encryption = Encryption.NONE;
+        }
+    }
+
     public void select_conversation(Conversation? conversation, bool default_initialize_conversation) {
         if (this.conversation != null) {
             conversation.notify["encryption"].disconnect(update_file_upload_status);
@@ -123,6 +206,8 @@ public class ConversationViewController : Object {
         }
 
         this.conversation = conversation;
+
+        update_conversation_encryption(conversation);
 
         // Set list model onto list view
 //        Dino.Application app = GLib.Application.get_default() as Dino.Application;

--- a/main/src/ui/settings_dialog.vala
+++ b/main/src/ui/settings_dialog.vala
@@ -1,4 +1,5 @@
 using Gtk;
+using Dino.Entities;
 
 namespace Dino.Ui {
 
@@ -9,6 +10,9 @@ class SettingsDialog : Adw.PreferencesWindow {
     [GtkChild] private unowned Switch marker_switch;
     [GtkChild] private unowned Switch notification_switch;
     [GtkChild] private unowned Switch emoji_switch;
+    [GtkChild] private unowned CheckButton encryption_radio_undecided;
+    [GtkChild] private unowned CheckButton encryption_radio_omemo;
+    [GtkChild] private unowned CheckButton encryption_radio_openpgp;
 
     Dino.Entities.Settings settings = Dino.Application.get_default().settings;
 
@@ -19,11 +23,34 @@ class SettingsDialog : Adw.PreferencesWindow {
         marker_switch.active = settings.send_marker;
         notification_switch.active = settings.notifications;
         emoji_switch.active = settings.convert_utf8_smileys;
+        encryption_radio_undecided.active = settings.default_encryption == Encryption.UNKNOWN;
+        encryption_radio_omemo.active = settings.default_encryption == Encryption.OMEMO;
+        encryption_radio_openpgp.active = settings.default_encryption == Encryption.PGP;
+
 
         typing_switch.notify["active"].connect(() => { settings.send_typing = typing_switch.active; } );
         marker_switch.notify["active"].connect(() => { settings.send_marker = marker_switch.active; } );
         notification_switch.notify["active"].connect(() => { settings.notifications = notification_switch.active; } );
         emoji_switch.notify["active"].connect(() => { settings.convert_utf8_smileys = emoji_switch.active; });
+
+        encryption_radio_undecided.notify["active"].connect(() => {
+            if (encryption_radio_undecided.active) {
+                settings.default_encryption = Encryption.UNKNOWN;
+            }
+        });
+
+        encryption_radio_omemo.notify["active"].connect(() => {
+            if (encryption_radio_omemo.active) {
+                settings.default_encryption = Encryption.OMEMO;
+            }
+        });
+
+        encryption_radio_openpgp.notify["active"].connect(() => {
+            if (encryption_radio_openpgp.active) {
+                settings.default_encryption = Encryption.PGP;
+            }
+        });
+
     }
 }
 


### PR DESCRIPTION
## Notice

This PR rebases https://github.com/dino/dino/pull/1236 on top of latest `master`, GTK4/`libadwaita`-based branch. The description below has been copied from the original PR, while the screenshots have been updated accordingly.

## Background

Despite Dino claiming _"no unencrypted chats leaving your computer"_ on [its website](https://dino.im/), truth is this only applies to *transport*-level encryption, whereas **end-to-end encryption is disabled by default**, which is a huge privacy risk for users. So far, OMEMO or OpenPGP must be explicitly enabled by the user from the encryption widget below, for each new conversation:

![image](https://user-images.githubusercontent.com/25252461/229257640-6595f352-97bb-4cc9-a9c1-b76a2615544e.png)

Several attempts at solving this issue have already been proposed:
- https://github.com/dino/dino/pull/845
- https://github.com/dino/dino/pull/632
- https://github.com/dino/dino/pull/1035

Unfortunately, all of them were unsuccessful since they preferred OMEMO as the default encryption method, a decision some contributors did not particularly agree with.

## Overview

Therefore, this PR instead prompts the user for a default encryption method, and stores this choice persistently for any new conversations. The first time a user starts a new chat, the following modal dialog shows up:

![image](https://user-images.githubusercontent.com/25252461/229944469-337c0992-9a78-4c9e-9a13-b4d67ef047ad.png)


### Features

- These settings are persistently stored into the database, and can be changed anytime from the settings menu, as shown below.

![image](https://user-images.githubusercontent.com/25252461/229257762-1d0baf97-1971-49b8-ab53-70bf7c4510a1.png)

- The modal dialog above is not shown for public chat rooms, following the same logic as the [encryption button](https://github.com/dino/dino/blob/99c076254abc6e2b03b784732a76a389e5a4f801/main/src/ui/chat_input/encryption_button.vala#L93-L102), or when a default encryption method has been already selected.
- Previous encryption settings for each conversation are respected.
     - In order not to break existing behaviour, this means **unencrypted chats are left as such, and the dialog above will only appear for new conversations**.

## Additional notes

- Neutrality over the decision to pick OpenPGP or OMEMO as the default encryption method has been respected as much as possible for this PR.
    - As for the settings menu, "Ask" is selected by default, so the modal dialog above appears when the user starts a new conversation.
- As opposed to the settings menu, XEP numbers for OMEMO and OpenPGP have been referenced on the modal dialog so users can search them in order to get a more informed decision.
- `Encryption.parse` was not in fact required (plain `int` could have been stored into the database instead of `string`), but makes it more readable when inspecting the database.

I hope this PR finally solves this issue, so users can enjoy end-to-end encrypted chats by default!