### PR TITLE
Focus ChatInput textbox after selecting emoji

### DIFF
--- a/main/src/ui/chat_input/view.vala
+++ b/main/src/ui/chat_input/view.vala
@@ -39,6 +39,8 @@ public class View : Box {
         chooser.emoji_picked.connect((emoji) => {
             chat_text_view.text_view.buffer.insert_at_cursor(emoji, emoji.data.length);
         });
+        chooser.closed.connect(do_focus);
+
         emoji_button.set_popover(chooser);
 
         file_button.tooltip_text = Util.string_if_tooltips_active(_("Send a file"));


### PR DESCRIPTION
After selecting an emoji, the emoji is inserted
into the textbox, but focus remains on the emoji_button.

This causes the EmojiChooser to be opened again if a user hits the Enter key directly, but text is inserted into the textbox if they continue to type.

This commit just explicitely focuses on the textbox after an emoji has been selected.

This also fixes #671 