### PR TITLE
A simple fix for I2P and Lokinet.

### DIFF
--- a/libdino/src/service/connection_manager.vala
+++ b/libdino/src/service/connection_manager.vala
@@ -382,9 +382,11 @@ public class ConnectionManager : Object {
     }
 
     public static bool on_invalid_certificate(string domain, TlsCertificate peer_cert, TlsCertificateFlags errors) {
-        if (domain.has_suffix(".onion") && errors == TlsCertificateFlags.UNKNOWN_CA) {
+        if ((domain.has_suffix(".onion") || domain.has_suffix(".i2p") || domain.has_suffix(".loki")) && errors == TlsCertificateFlags.UNKNOWN_CA) {
             // It's barely possible for .onion servers to provide a non-self-signed cert.
-            // But that's fine because encryption is provided independently though TOR.
+            // But that's fine because encryption is provided independently though Tor.
+            // Same for .i2p servers on I2P, and .loki servers on Lokinet.
+            // Although maintaining exceptions for mixnet TLDs could become overwhelming soon.
             warning("Accepting TLS certificate from unknown CA from .onion address %s", domain);
             return true;
         }


### PR DESCRIPTION
A simple fix for I2P and Lokinet.

The job of maintaining TLDs for mixnet TLDs can become overwhelming, just saying. Better to just offer a togglable option to allow untrusted certificates.