### PR TITLE
application: Automatically load help overlay

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -67,6 +67,7 @@ set(RESOURCE_LIST
     file_default_widget.ui
     file_send_overlay.ui
     global_search.ui
+    gtk/help-overlay.ui
     conversation_content_view/item_metadata_header.ui
     conversation_content_view/view.ui
     manage_accounts/account_row.ui
@@ -82,7 +83,6 @@ set(RESOURCE_LIST
     quote.ui
     search_autocomplete.ui
     settings_dialog.ui
-    gtk/help-overlay.ui
     unified_main_content.ui
     unified_window_placeholder.ui
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -82,7 +82,7 @@ set(RESOURCE_LIST
     quote.ui
     search_autocomplete.ui
     settings_dialog.ui
-    shortcuts.ui
+    gtk/help-overlay.ui
     unified_main_content.ui
     unified_window_placeholder.ui
 

--- a/main/data/gresource.xml
+++ b/main/data/gresource.xml
@@ -20,6 +20,7 @@
     <file>file_default_widget.ui</file>
     <file>file_send_overlay.ui</file>
     <file>global_search.ui</file>
+    <file>gtk/help-overlay.ui</file>
     <file>icons/scalable/actions/dino-emoticon-add-symbolic.svg</file>
     <file>icons/scalable/actions/dino-qr-code-symbolic.svg</file>
     <file>icons/scalable/apps/im.dino.Dino-symbolic.svg</file>
@@ -61,7 +62,6 @@
     <file>quote.ui</file>
     <file>search_autocomplete.ui</file>
     <file>settings_dialog.ui</file>
-    <file>gtk/help-overlay.ui</file>
     <file>style-dark.css</file>
     <file>style.css</file>
     <file>unified_main_content.ui</file>

--- a/main/data/gresource.xml
+++ b/main/data/gresource.xml
@@ -61,11 +61,10 @@
     <file>quote.ui</file>
     <file>search_autocomplete.ui</file>
     <file>settings_dialog.ui</file>
-    <file>shortcuts.ui</file>
+    <file>gtk/help-overlay.ui</file>
     <file>style-dark.css</file>
     <file>style.css</file>
     <file>unified_main_content.ui</file>
     <file>unified_window_placeholder.ui</file>
   </gresource>
 </gresources>
-

--- a/main/data/gtk/help-overlay.ui
+++ b/main/data/gtk/help-overlay.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-    <object class="GtkShortcutsWindow" id="shortcuts-window">
+    <object class="GtkShortcutsWindow" id="help_overlay">
         <property name="modal">True</property>
         <child>
             <object class="GtkShortcutsSection">

--- a/main/data/menu_app.ui
+++ b/main/data/menu_app.ui
@@ -13,7 +13,7 @@
                 <attribute name="label" translatable="yes">Preferences</attribute>
             </item>
             <item>
-                <attribute name="action">app.open_shortcuts</attribute>
+                <attribute name="action">win.show-help-overlay</attribute>
                 <attribute name="label" translatable="yes">Keyboard Shortcuts</attribute>
             </item>
             <item>

--- a/main/src/ui/application.vala
+++ b/main/src/ui/application.vala
@@ -195,20 +195,6 @@ public class Dino.Ui.Application : Adw.Application, Dino.Application {
         add_action(loop_conversations_bw_action);
         set_accels_for_action("app.loop_conversations_bw", KEY_COMBINATION_LOOP_CONVERSATIONS_REV);
 
-        SimpleAction open_shortcuts_action = new SimpleAction("open_shortcuts", null);
-        open_shortcuts_action.activate.connect((variant) => {
-            Builder builder = new Builder.from_resource("/im/dino/Dino/shortcuts.ui");
-            ShortcutsWindow dialog = (ShortcutsWindow) builder.get_object("shortcuts-window");
-            if (!use_csd()) {
-                dialog.set_titlebar(null);
-            }
-            dialog.title = _("Keyboard Shortcuts");
-            dialog.set_transient_for(get_active_window());
-            dialog.present();
-        });
-        add_action(open_shortcuts_action);
-        set_accels_for_action("app.open_shortcuts", KEY_COMBINATION_SHOW_KEYBOARD_SHORTCUTS);
-
         SimpleAction accept_call_action = new SimpleAction("accept-call", new VariantType.tuple(new VariantType[]{VariantType.INT32, VariantType.INT32}));
         accept_call_action.activate.connect((variant) => {
             int conversation_id = variant.get_child_value(0).get_int32();

--- a/main/src/ui/application.vala
+++ b/main/src/ui/application.vala
@@ -10,7 +10,6 @@ public class Dino.Ui.Application : Adw.Application, Dino.Application {
     private const string[] KEY_COMBINATION_ADD_CONFERENCE = {"<Ctrl>G", null};
     private const string[] KEY_COMBINATION_LOOP_CONVERSATIONS = {"<Ctrl>Tab", null};
     private const string[] KEY_COMBINATION_LOOP_CONVERSATIONS_REV = {"<Ctrl><Shift>Tab", null};
-    private const string[] KEY_COMBINATION_SHOW_KEYBOARD_SHORTCUTS = {"<Ctrl>question", null};
 
     private MainWindow window;
     public MainWindowController controller;

--- a/main/src/ui/main_window.vala
+++ b/main/src/ui/main_window.vala
@@ -6,7 +6,7 @@ using Dino.Entities;
 
 namespace Dino.Ui {
 
-public class MainWindow : Adw.Window {
+public class MainWindow : Adw.ApplicationWindow {
 
     public signal void conversation_selected(Conversation conversation);
 


### PR DESCRIPTION
GTK automatically loads certain resources for you when using the right tools. This MR
changes Dino's main window to use AdwApplicationWindow and the shortcuts.ui file
into help-overlay.ui. This is so GTK can automatically load the file, set up the
action, and set the keyboard shortcut for the action.

See https://docs.gtk.org/gtk4/class.Application.html#automatic-resources
