### PR TITLE
Fix showing the kick option to owners

### DIFF
--- a/xmpp-vala/src/module/xep/0045_muc/module.vala
+++ b/xmpp-vala/src/module/xep/0045_muc/module.vala
@@ -203,6 +203,8 @@ public class Module : XmppStreamModule {
                 case Affiliation.ADMIN:
                     if (other_affiliation == Affiliation.OWNER) return false;
                     break;
+                case Affiliation.OWNER:
+                    return true;
                 default:
                     return false;
             }


### PR DESCRIPTION
Missing case in the switch defaulted to returning false for Owners, thus preventing they with the most privileges from using those privileges.