### PR TITLE
Obfuscate password length in account dialog (fixes #797)

### DIFF
--- a/main/src/ui/manage_accounts/dialog.vala
+++ b/main/src/ui/manage_accounts/dialog.vala
@@ -44,8 +44,10 @@ public class Dialog : Gtk.Dialog {
         image_button.clicked.connect(show_select_avatar);
         alias_hybrid.entry.changed.connect(() => { selected_account.alias = alias_hybrid.text; });
         password_hybrid.entry.changed.connect(() => {
-            if (password_hybrid.text != "************") {
-                selected_account.password = password_hybrid.text;
+            string? pw_buffer;
+            pw_buffer = password_hybrid.text;
+            if (pw_buffer != null && pw_buffer.length > 0 && pw_buffer != "************") {
+              selected_account.password = pw_buffer;
             }
         });
 

--- a/main/src/ui/manage_accounts/dialog.vala
+++ b/main/src/ui/manage_accounts/dialog.vala
@@ -43,7 +43,11 @@ public class Dialog : Gtk.Dialog {
         });
         image_button.clicked.connect(show_select_avatar);
         alias_hybrid.entry.changed.connect(() => { selected_account.alias = alias_hybrid.text; });
-        password_hybrid.entry.changed.connect(() => { selected_account.password = password_hybrid.text; });
+        password_hybrid.entry.changed.connect(() => {
+            if (password_hybrid.text != "************") {
+                selected_account.password = password_hybrid.text;
+            }
+        });
 
         Util.LabelHybridGroup label_hybrid_group = new Util.LabelHybridGroup();
         label_hybrid_group.add(alias_hybrid);
@@ -65,6 +69,7 @@ public class Dialog : Gtk.Dialog {
 
             settings_list.attach(widget, 1, row_index, 2);
             row_index++;
+            password_hybrid.text = "************";
         }
     }
 
@@ -191,7 +196,7 @@ public class Dialog : Gtk.Dialog {
 
         alias_hybrid.text = account.alias ?? "";
         password_hybrid.entry.input_purpose = InputPurpose.PASSWORD;
-        password_hybrid.text = account.password;
+        
 
         update_status_label(account);
 


### PR DESCRIPTION
Closes issue #797.
By default, it displays a password length of 12 characters regardless of the real password length.