### PR TITLE
Add a way to close conversation from conversation dialog(#1321)

### DIFF
--- a/main/data/contact_details_dialog.ui
+++ b/main/data/contact_details_dialog.ui
@@ -100,6 +100,18 @@
                                         <property name="margin-start">100</property>
                                     </object>
                                 </child>
+                                <child>
+                                  <object class="GtkButton" id="close_conversation">
+                                    <property name="margin-end">100</property>
+                                    <property name="margin-start">100</property>
+                                    <property name="margin-top">18</property>
+                                    <property name="margin-bottom">18</property>
+                                    <property name="label" translatable="yes">Close Conversation</property>
+                                    <style>
+                                      <class name="destructive-action"/>
+                                    </style>
+                                  </object>
+                                </child>
                             </object>
                         </property>
                     </object>

--- a/main/src/ui/contact_details/dialog.vala
+++ b/main/src/ui/contact_details/dialog.vala
@@ -16,6 +16,7 @@ public class Dialog : Gtk.Dialog {
     [GtkChild] public unowned Label jid_label;
     [GtkChild] public unowned Label account_label;
     [GtkChild] public unowned Box main_box;
+    [GtkChild] public unowned Button close_conversation;
 
     private StreamInteractor stream_interactor;
     private Conversation conversation;
@@ -67,6 +68,11 @@ public class Dialog : Gtk.Dialog {
         close_request.connect(() => {
             contact_details.save();
             return false;
+        });
+		
+        close_conversation.clicked.connect(() => {
+            stream_interactor.get_module(ConversationManager.IDENTITY).close_conversation(conversation);
+            close();
         });
     }
 


### PR DESCRIPTION
It's currently not possible to close a conversation on mobile phones as the close button on conversation row is shown on hover which is not possible on touch only devices.

Also, hovering to close may occasionally result in the wrong item being closed in case a new conversation is open somewhere before the to be closed item.

So add a button to conversation dialog so that users can close the conversation on mobile phones