### PR TITLE
More Image Leaks

### DIFF
--- a/main/src/ui/conversation_content_view/file_image_widget.vala
+++ b/main/src/ui/conversation_content_view/file_image_widget.vala
@@ -8,6 +8,10 @@ namespace Dino.Ui {
 
 public class FileImageWidget : Box {
 
+    Gtk.Box image_overlay_toolbar;
+    MenuButton button;
+    GestureClick gesture_click_controller;
+
     public FileImageWidget() {
         this.halign = Align.START;
 
@@ -15,39 +19,51 @@ public class FileImageWidget : Box {
         this.set_cursor_from_name("zoom-in");
     }
 
+    private void mouse_on_enter() {
+        image_overlay_toolbar.visible = true;
+    }
+
+    private void mouse_on_leave() {
+        if (button.popover != null && button.popover.visible) return;
+
+        image_overlay_toolbar.visible = false;
+    }
+
+    private void on_click_release(int n_press, double x, double y) {
+        switch (gesture_click_controller.get_device().source) {
+            case Gdk.InputSource.TOUCHSCREEN:
+            case Gdk.InputSource.PEN:
+                if (n_press == 1) {
+                    image_overlay_toolbar.visible = !image_overlay_toolbar.visible;
+                } else if (n_press == 2) {
+                    this.activate_action("file.open", null);
+                    image_overlay_toolbar.visible = false;
+                }
+                break;
+            default:
+                this.activate_action("file.open", null);
+                image_overlay_toolbar.visible = false;
+                break;
+        }
+    }
+
     public async void load_from_file(File file, string file_name, int MAX_WIDTH=600, int MAX_HEIGHT=300) throws GLib.Error {
-        Gtk.Box image_overlay_toolbar = new Gtk.Box(Orientation.HORIZONTAL, 0) { halign=Gtk.Align.END, valign=Gtk.Align.START, margin_top=10, margin_start=10, margin_end=10, margin_bottom=10, vexpand=false, visible=false };
+        image_overlay_toolbar = new Gtk.Box(Orientation.HORIZONTAL, 0) { halign=Gtk.Align.END, valign=Gtk.Align.START, margin_top=10, margin_start=10, margin_end=10, margin_bottom=10, vexpand=false, visible=false };
         image_overlay_toolbar.add_css_class("card");
         image_overlay_toolbar.add_css_class("toolbar");
         image_overlay_toolbar.add_css_class("overlay-toolbar");
         image_overlay_toolbar.set_cursor_from_name("default");
 
         FixedRatioPicture image = new FixedRatioPicture() { min_width=100, min_height=100, max_width=MAX_WIDTH, max_height=MAX_HEIGHT, file=file };
-        GestureClick gesture_click_controller = new GestureClick();
+        gesture_click_controller = new GestureClick();
         gesture_click_controller.button = 1; // listen for left clicks
-        gesture_click_controller.released.connect((n_press, x, y) => {
-            switch (gesture_click_controller.get_device().source) {
-                case Gdk.InputSource.TOUCHSCREEN:
-                case Gdk.InputSource.PEN:
-                    if (n_press == 1) {
-                        image_overlay_toolbar.visible = !image_overlay_toolbar.visible;
-                    } else if (n_press == 2) {
-                        this.activate_action("file.open", null);
-                        image_overlay_toolbar.visible = false;
-                    }
-                    break;
-                default:
-                    this.activate_action("file.open", null);
-                    image_overlay_toolbar.visible = false;
-                    break;
-            }
-        });
+        gesture_click_controller.released.connect(on_click_release);
         image.add_controller(gesture_click_controller);
 
         FileInfo file_info = file.query_info("*", FileQueryInfoFlags.NONE);
         string? mime_type = file_info.get_content_type();
 
-        MenuButton button = new MenuButton();
+        button = new MenuButton();
         button.icon_name = "open-menu";
         Menu menu_model = new Menu();
         menu_model.append(_("Open"), "file.open");
@@ -65,14 +81,8 @@ public class FileImageWidget : Box {
 
         EventControllerMotion this_motion_events = new EventControllerMotion();
         this.add_controller(this_motion_events);
-        this_motion_events.enter.connect(() => {
-            image_overlay_toolbar.visible = true;
-        });
-        this_motion_events.leave.connect(() => {
-            if (button.popover != null && button.popover.visible) return;
-
-            image_overlay_toolbar.visible = false;
-        });
+        this_motion_events.enter.connect(mouse_on_enter);
+        this_motion_events.leave.connect(mouse_on_leave);
 
         this.append(overlay);
     }

--- a/main/src/ui/conversation_view_controller.vala
+++ b/main/src/ui/conversation_view_controller.vala
@@ -14,6 +14,7 @@ public class ConversationViewController : Object {
     private Application app;
     private ConversationView view;
     private Widget? overlay_dialog;
+    private FileSendOverlay overlay;
     private ConversationTitlebar titlebar;
     public SearchMenuEntry search_menu_entry = new SearchMenuEntry();
     public ListView list_view = new ListView(null, null);
@@ -226,7 +227,7 @@ public class ConversationViewController : Object {
             file_info = file.query_info("*", FileQueryInfoFlags.NONE);
         } catch (Error e) { return; }
 
-        FileSendOverlay overlay = new FileSendOverlay(file, file_info);
+        overlay = new FileSendOverlay(file, file_info);
         overlay.send_file.connect(() => send_file(file));
 
         stream_interactor.get_module(FileManager.IDENTITY).get_file_size_limits.begin(conversation, (_, res) => {
@@ -248,6 +249,7 @@ public class ConversationViewController : Object {
             // We don't want drag'n'drop to be active while the overlay is active
             overlay_dialog = null;
             update_file_upload_status.begin();
+            GLib.Idle.add(() => { overlay = null; return false; });
         });
 
         view.add_overlay_dialog(overlay.get_widget());


### PR DESCRIPTION
While building animated gifs I had some tracing on to make sure I wasn't introducing any leaks, and found some more that were pre-existing, but unrelated to animated GIFs.

The first was a cycle where hooking up the overlay in the file widget introduced a cycle that kept the file widget around even when the parent view was destroyed. I believe this one actually _kinda_ works as-is, because the parent view in practice calls `dispose()` manually on the children, but that's a bit fragile and still isn't quite the same. But then when I implemented #1483 the parent became a standard Expander widget with no special handling, and then it was really broken. So this makes it so any standard widget can be the parent.

The second was the "FileSendOverlay" which was created as a stack variable and then not referenced anywhere else. So that should have crashed immediately, but the leaking from the two callbacks in scope kept it around forever instead. So what I did here was actually reference it from the conversation view controller and then explicitly clear it after the overlay closes (with a slight delay, since that's in a handler on a signal on that object, and it crashes if I free it from that context). I can be a bit looser here because this `this` in this context is the `ConversationViewController`, which appears to functionally be a singleton.