### PR TITLE
CMake, configure: Force `libsoup` version

### DIFF
--- a/cmake/SoupVersion.cmake
+++ b/cmake/SoupVersion.cmake
@@ -34,7 +34,7 @@ elseif (NOT SOUP_VERSION)
     find_package(Soup2 QUIET)
     find_package(Soup3 QUIET)
     # Only use libsoup 3 if specifically requested or when libsoup 2 is not available
-    if (Soup3_FOUND AND NOT Soup2_FOUND OR USE_SOUP3)
+    if (Soup3_FOUND AND NOT Soup2_FOUND)
         set(SOUP_VERSION 3)
     else ()
         set(SOUP_VERSION 2)

--- a/cmake/SoupVersion.cmake
+++ b/cmake/SoupVersion.cmake
@@ -1,5 +1,5 @@
 find_package(Nice QUIET)
-if (Nice_FOUND AND NOT SOUP_VERSION AND NOT USE_SOUP3)
+if (Nice_FOUND)
     file(GET_RUNTIME_DEPENDENCIES
         RESOLVED_DEPENDENCIES_VAR Nice_DEPENDENCIES
         UNRESOLVED_DEPENDENCIES_VAR Nice_UNRESOLVED_DEPENDENCIES
@@ -9,11 +9,21 @@ if (Nice_FOUND AND NOT SOUP_VERSION AND NOT USE_SOUP3)
     )
     foreach (lib ${Nice_DEPENDENCIES})
         if (lib MATCHES ".*/libsoup-3.*")
+            if(SOUP_VERSION AND NOT SOUP_VERSION EQUAL 3)
+                message(FATAL_ERROR "libnice-${Nice_VERSION} depends on "
+                    "libsoup-3, but SOUP_VERSION=${SOUP_VERSION} was given.")
+            endif()
+
             set(SOUP_VERSION 3)
         endif ()
     endforeach ()
     foreach (lib ${Nice_DEPENDENCIES})
         if (lib MATCHES ".*/libsoup-2.*")
+            if(SOUP_VERSION AND NOT SOUP_VERSION EQUAL 2)
+                message(FATAL_ERROR "libnice-${Nice_VERSION} depends on "
+                    "libsoup-2, but SOUP_VERSION=${SOUP_VERSION} was given.")
+            endif()
+
             set(SOUP_VERSION 2)
         endif ()
     endforeach ()

--- a/configure
+++ b/configure
@@ -20,7 +20,7 @@ BUILD_TYPE=Debug
 DISABLE_FAST_VAPI=
 LIB_SUFFIX=
 NO_DEBUG=
-USE_SOUP3=
+SOUP_VERSION=2
 
 EXEC_PREFIX=
 BINDIR=
@@ -108,7 +108,7 @@ while true; do
         --valac ) VALA_EXECUTABLE="$2"; shift; shift ;;
         --valac-flags ) VALAC_FLAGS="$2"; shift; shift ;;
         --lib-suffix ) LIB_SUFFIX="$2"; shift; shift ;;
-        --with-libsoup3 ) USE_SOUP3=yes; shift ;;
+        --with-libsoup3 ) SOUP_VERSION=3; shift ;;
         --disable-fast-vapi ) DISABLE_FAST_VAPI=yes; shift ;;
         --no-debug ) NO_DEBUG=yes; shift ;;
         --release ) BUILD_TYPE=RelWithDebInfo; shift ;;
@@ -208,7 +208,7 @@ cmake -G "$cmake_type" \
     -DENABLED_PLUGINS="$ENABLED_PLUGINS" \
     -DDISABLED_PLUGINS="$DISABLED_PLUGINS" \
     -DBUILD_TESTS="$BUILD_TESTS" \
-    -DUSE_SOUP3="$USE_SOUP3" \
+    -DSOUP_VERSION="$SOUP_VERSION" \
     -DVALA_EXECUTABLE="$VALAC" \
     -DCMAKE_VALA_FLAGS="$VALACFLAGS" \
     -DDISABLE_FAST_VAPI="$DISABLE_FAST_VAPI" \


### PR DESCRIPTION
Whereas Dino did check which `libsoup` version was required by `libnice`, it did nothing to stop the user from linking against an invalid version, leading to the following error message on startup:

```
(dino:191348): libsoup-ERROR **: 22:55:21.446: libsoup2 symbols detected. Using libsoup2 and libsoup3 in the same process is not supported.
Trace/breakpoint trap (core dumped)
```

Stricter checks have been added to avoid this situation. On the other hand, `USE_SOUP3` was removed in favour of `SOUP_VERSION`, which is the only CMake variable that was being consistently used for this purpose.