### PR TITLE
Show file upload/download progress

### DIFF
--- a/libdino/src/entity/file_transfer.vala
+++ b/libdino/src/entity/file_transfer.vala
@@ -71,6 +71,7 @@ public class FileTransfer : Object {
     public int provider { get; set; }
     public string info { get; set; }
     public Cancellable cancellable { get; default=new Cancellable(); }
+    public uint64 transferred_bytes { get; set; }
 
     private Database? db;
     private string storage_dir;

--- a/libdino/src/service/jingle_file_transfers.vala
+++ b/libdino/src/service/jingle_file_transfers.vala
@@ -220,7 +220,19 @@ public class JingleFileSender : FileSender, Object {
                 }
             }
             try {
-                yield stream.get_module(Xep.JingleFileTransfer.Module.IDENTITY).offer_file_stream(stream, full_jid, file_transfer.input_stream, file_transfer.server_file_name, file_meta.size, precondition_name, precondition_options);
+                var? module = stream.get_module(Xep.JingleFileTransfer.Module.IDENTITY);
+
+                if (module == null)
+                    throw new FileSendError.UPLOAD_FAILED("unexpected null module");
+
+                module.transferred_bytes.connect((bytes) => {
+                    file_transfer.transferred_bytes += bytes;
+                });
+
+                yield module.offer_file_stream(stream, full_jid,
+                    file_transfer.cancellable, file_transfer.input_stream,
+                    file_transfer.server_file_name, file_meta.size,
+                    precondition_name, precondition_options);
             } catch (Error e) {
                 throw new FileSendError.UPLOAD_FAILED(@"offer_file_stream failed: $(e.message)");
             }

--- a/main/src/ui/conversation_content_view/file_default_widget.vala
+++ b/main/src/ui/conversation_content_view/file_default_widget.vala
@@ -39,7 +39,8 @@ public class FileDefaultWidget : Box {
         });
     }
 
-    public void update_file_info(string? mime_type, FileTransfer.State state, long size) {
+    public void update_file_info(string? mime_type, uint64 transferred_bytes,
+        bool direction, FileTransfer.State state, long size) {
         this.state = state;
 
         spinner.stop(); // A hidden spinning spinner still uses CPU. Deactivate asap
@@ -61,7 +62,17 @@ public class FileDefaultWidget : Box {
                 popover_menu.closed.connect(on_pointer_left);
                 break;
             case FileTransfer.State.IN_PROGRESS:
-                mime_label.label = _("Downloading %s…").printf(get_size_string(size));
+                uint progress = 0;
+
+                if (size > 0)
+                    progress = (uint)((transferred_bytes * (uint64)100) / (uint64)size);
+
+                if (direction == FileTransfer.DIRECTION_SENT) {
+                    mime_label.label = _("Uploading %s (%u%%)…").printf(get_size_string(size), progress);
+                }
+                else {
+                    mime_label.label = _("Downloading %s (%u%%)…").printf(get_size_string(size), progress);
+                }
                 spinner.start();
                 image_stack.set_visible_child_name("spinner");
 

--- a/main/src/ui/conversation_content_view/file_widget.vala
+++ b/main/src/ui/conversation_content_view/file_widget.vala
@@ -89,7 +89,8 @@ public class FileWidget : SizeRequestBox {
     }
 
     private async void update_widget() {
-        if (show_image() && state != State.IMAGE) {
+        if (show_image() && state != State.IMAGE
+            && file_transfer.state == FileTransfer.State.COMPLETE) {
             var content_bak = content;
 
             FileImageWidget file_image_widget = null;
@@ -108,7 +109,7 @@ public class FileWidget : SizeRequestBox {
             } catch (Error e) { }
         }
 
-        if (!show_image() && state != State.DEFAULT) {
+        if (state != State.DEFAULT) {
             if (content != null) this.remove(content);
             FileDefaultWidget default_file_widget = new FileDefaultWidget();
             default_widget_controller = new FileDefaultWidgetController(default_file_widget);
@@ -215,6 +216,7 @@ public class FileDefaultWidgetController : Object {
     private FileTransfer? file_transfer;
     public string file_transfer_state { get; set; }
     public string file_transfer_mime_type { get; set; }
+    public uint64 file_transfer_transferred_bytes { get; set; }
 
     private FileTransfer.State state;
 
@@ -225,6 +227,7 @@ public class FileDefaultWidgetController : Object {
 
         this.notify["file-transfer-state"].connect(update_file_info);
         this.notify["file-transfer-mime-type"].connect(update_file_info);
+        this.notify["file-transfer-transferred-bytes"].connect(update_file_info);
     }
 
     public void set_file_transfer(FileTransfer file_transfer) {
@@ -234,13 +237,15 @@ public class FileDefaultWidgetController : Object {
 
         file_transfer.bind_property("state", this, "file-transfer-state");
         file_transfer.bind_property("mime-type", this, "file-transfer-mime-type");
+        file_transfer.bind_property("transferred-bytes", this, "file-transfer-transferred-bytes");
 
         update_file_info();
     }
 
     private void update_file_info() {
         state = file_transfer.state;
-        widget.update_file_info(file_transfer.mime_type, file_transfer.state, file_transfer.size);
+        widget.update_file_info(file_transfer.mime_type, file_transfer.transferred_bytes,
+            file_transfer.direction, file_transfer.state, file_transfer.size);
     }
 
     private void on_clicked() {

--- a/main/src/ui/file_send_overlay.vala
+++ b/main/src/ui/file_send_overlay.vala
@@ -81,7 +81,8 @@ public class FileSendOverlay {
         if (widget == null) {
             FileDefaultWidget default_widget = new FileDefaultWidget();
             default_widget.name_label.label = file_name;
-            default_widget.update_file_info(mime_type, FileTransfer.State.COMPLETE, (long)file_info.get_size());
+            default_widget.update_file_info(mime_type, 0, FileTransfer.DIRECTION_SENT,
+                FileTransfer.State.COMPLETE, (long)file_info.get_size());
             widget = default_widget;
         }
 

--- a/plugins/http-files/src/file_sender.vala
+++ b/plugins/http-files/src/file_sender.vala
@@ -103,6 +103,18 @@ public class HttpFileSender : FileSender, Object {
         put_message.wrote_headers.connect(() => transfer_more_bytes(file_transfer.input_stream, put_message.request_body));
         put_message.wrote_chunk.connect(() => transfer_more_bytes(file_transfer.input_stream, put_message.request_body));
 #endif
+
+        file_transfer.transferred_bytes = 0;
+        put_message.wrote_body_data.connect((chunk) => {
+            if (file_transfer.size != 0) {
+#if SOUP_3_0
+                file_transfer.transferred_bytes += chunk;
+#else
+                file_transfer.transferred_bytes += chunk.length;
+#endif
+            }
+        });
+
         foreach (var entry in file_send_data.headers.entries) {
             put_message.request_headers.append(entry.key, entry.value);
         }


### PR DESCRIPTION
Fixes upstream issue #1350.

https://github.com/dino/dino/assets/25252461/2ff0dfd8-ad39-4d3c-9dd4-598ff8c4c746


## Notes

Image uploads were incorrectly handled by Dino, as they were always reported as completed even if they were not, maybe so as to show the image preview from the start. Now, Dino shows the upload progress for all file types, and the image is only shown when completed.