### PR TITLE
Fix segfault opening conversation details when no XEP-0191 support 

### DIFF
--- a/xmpp-vala/src/module/xep/0191_blocking_command.vala
+++ b/xmpp-vala/src/module/xep/0191_blocking_command.vala
@@ -14,8 +14,7 @@ public class Module : XmppStreamModule, Iq.Handler {
     public bool is_blocked(XmppStream stream, string jid) {
         if (is_supported(stream)){
             return stream.get_flag(Flag.IDENTITY).blocklist.contains(jid);
-        }
-        else {
+        } else {
             return false;
         }
     }

--- a/xmpp-vala/src/module/xep/0191_blocking_command.vala
+++ b/xmpp-vala/src/module/xep/0191_blocking_command.vala
@@ -12,7 +12,12 @@ public class Module : XmppStreamModule, Iq.Handler {
     public signal void unblock_all_received(XmppStream stream);
 
     public bool is_blocked(XmppStream stream, string jid) {
-        return stream.get_flag(Flag.IDENTITY).blocklist.contains(jid);
+        if (is_supported(stream)){
+            return stream.get_flag(Flag.IDENTITY).blocklist.contains(jid);
+        }
+        else {
+            return false;
+        }
     }
 
     public bool block(XmppStream stream, string[] jids) {

--- a/xmpp-vala/src/module/xep/0191_blocking_command.vala
+++ b/xmpp-vala/src/module/xep/0191_blocking_command.vala
@@ -12,7 +12,7 @@ public class Module : XmppStreamModule, Iq.Handler {
     public signal void unblock_all_received(XmppStream stream);
 
     public bool is_blocked(XmppStream stream, string jid) {
-        if (is_supported(stream)){
+        if (is_supported(stream)) {
             return stream.get_flag(Flag.IDENTITY).blocklist.contains(jid);
         } else {
             return false;


### PR DESCRIPTION
should close https://github.com/dino/dino/issues/1508

It also removes the block button from conv details when it's not supported.