### PR TITLE
Set MessageMetaItem.label.selectable to false when run on touchscreen

### DIFF
--- a/main/src/ui/conversation_content_view/message_widget.vala
+++ b/main/src/ui/conversation_content_view/message_widget.vala
@@ -29,7 +29,7 @@ public class MessageMetaItem : ContentMetaItem {
     ulong style_updated_id = -1;
     ulong marked_notify_handler_id = -1;
 
-    public Label label = new Label("") { use_markup=true, xalign=0, selectable=true, wrap=true, wrap_mode=Pango.WrapMode.WORD_CHAR, hexpand=true, vexpand=true };
+    public Label label = new Label("") { use_markup=true, xalign=0, selectable=!Dino.Ui.on_touchscreen(), wrap=true, wrap_mode=Pango.WrapMode.WORD_CHAR, hexpand=true, vexpand=true };
 
     public MessageMetaItem(ContentItem content_item, StreamInteractor stream_interactor) {
         base(content_item);

--- a/main/src/ui/util/config.vala
+++ b/main/src/ui/util/config.vala
@@ -5,6 +5,10 @@ using Dino.Entities;
 
 namespace Dino.Ui {
 
+public bool on_touchscreen() {
+    return (Gdk.Display.get_default().get_default_seat().get_capabilities() & Gdk.SeatCapabilities.TOUCH) != 0;
+}
+
 public class Config : Object {
 
     public Database db { get; private set; }


### PR DESCRIPTION
Add new function Dino.Ui.on_touchscreen() which returns true when Dino is run on a touchscreen device. Use this function to set the selectable property on MessageMetaItem labels.

This makes it possible to move from the conversation view to the conversation list by swiping.