### PR TITLE
Fix gcc error when compiling openpgp plugin

### DIFF
--- a/plugins/openpgp/src/gpgme_fix.c
+++ b/plugins/openpgp/src/gpgme_fix.c
@@ -1,6 +1,6 @@
 #include <gpgme_fix.h>
 
-GRecMutex gpgme_global_mutex = {0};
+static GRecMutex gpgme_global_mutex = {0};
 
 gpgme_key_t gpgme_key_ref_vapi (gpgme_key_t key) {
     gpgme_key_ref(key);


### PR DESCRIPTION
gcc was complaining about _**error**: non-static declaration of 'gpgme_global_mutex' follows static declaration_ in `plugins/openpgp/src/gpgme_fix.c`

After this I was able to compile the plugin and test it fine.