### PR TITLE
Make OMEMO plugin UI adaptive

### DIFF
--- a/plugins/omemo/data/contact_details_dialog.ui
+++ b/plugins/omemo/data/contact_details_dialog.ui
@@ -126,20 +126,17 @@
                                                                                         <child>
                                                                                             <object class="GtkMenuButton" id="show_qrcode_button">
                                                                                                 <property name="icon-name">dino-qr-code-symbolic</property>
-                                                                                                <property name="halign">start</property>
                                                                                                 <property name="hexpand">1</property>
+                                                                                                <property name="halign">end</property>
+                                                                                                <property name="valign">center</property>
                                                                                             </object>
                                                                                         </child>
                                                                                         <child>
                                                                                             <object class="GtkButton" id="copy_button">
-                                                                                                <property name="halign">end</property>
+                                                                                                <property name="icon-name">edit-copy-symbolic</property>
                                                                                                 <property name="hexpand">1</property>
-                                                                                                <child>
-                                                                                                    <object class="GtkImage">
-                                                                                                        <property name="icon-size">normal</property>
-                                                                                                        <property name="icon-name">edit-copy-symbolic</property>
-                                                                                                    </object>
-                                                                                                </child>
+                                                                                                <property name="halign">end</property>
+                                                                                                <property name="valign">center</property>
                                                                                             </object>
                                                                                         </child>
                                                                                     </object>

--- a/plugins/omemo/data/contact_details_dialog.ui
+++ b/plugins/omemo/data/contact_details_dialog.ui
@@ -3,230 +3,231 @@
     <requires lib="gtk" version="4.0"/>
     <template class="DinoPluginsOmemoContactDetailsDialog">
         <property name="modal">True</property>
-        <property name="resizable">False</property>
+        <property name="default-width">480</property>
         <child internal-child="content_area">
             <object class="GtkBox">
-                <property name="margin-start">12</property>
-                <property name="margin-end">12</property>
-                <property name="margin-top">12</property>
-                <property name="margin-bottom">12</property>
-                <property name="spacing">12</property>
+                <property name="orientation">vertical</property>
                 <child>
-                    <object class="GtkFrame">
+                    <object class="GtkScrolledWindow">
+                        <property name="hscrollbar_policy">never</property>
+                        <property name="propagate_natural_height">1</property>
                         <property name="child">
-                            <object class="GtkListBox">
-                                <property name="selection-mode">none</property>
+                            <object class="AdwClamp">
+                                <property name="maximum-size">400</property>
+                                <property name="tightening-threshold">300</property>
                                 <child>
-                                    <object class="GtkListBoxRow">
-                                        <property name="activatable">0</property>
-                                        <property name="child">
-                                            <object class="GtkBox">
-                                                <property name="margin-start">20</property>
-                                                <property name="margin-end">20</property>
-                                                <property name="margin-top">14</property>
-                                                <property name="margin-bottom">14</property>
-                                                <property name="spacing">40</property>
-                                                <child>
-                                                    <object class="GtkBox">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="hexpand">1</property>
-                                                        <child>
-                                                            <object class="GtkLabel" id="automatically_accept_new_label">
-                                                                <property name="halign">start</property>
-                                                                <attributes>
-                                                                    <attribute name="scale" value="1.1"></attribute>
-                                                                </attributes>
-                                                            </object>
-                                                        </child>
-                                                        <child>
-                                                            <object class="GtkLabel" id="automatically_accept_new_descr">
-                                                                <property name="max_width_chars">1</property>
-                                                                <property name="hexpand">1</property>
-                                                                <property name="vexpand">1</property>
-                                                                <property name="xalign">0</property>
-                                                                <property name="wrap">1</property>
-                                                                <attributes>
-                                                                    <attribute name="scale" value="0.8"></attribute>
-                                                                </attributes>
-                                                                <style>
-                                                                    <class name="dim-label"/>
-                                                                </style>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkSwitch" id="auto_accept_switch">
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </property>
-                                    </object>
-                                </child>
-                            </object>
-                        </property>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox" id="own_fingerprint_container">
-                        <property name="visible">0</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">2</property>
-                        <child>
-                            <object class="GtkLabel" id="own_key_label">
-                                <property name="halign">start</property>
-                                <attributes>
-                                    <attribute name="weight" value="PANGO_WEIGHT_BOLD"></attribute>
-                                </attributes>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkFrame">
-                                <property name="child">
-                                    <object class="GtkListBox">
-                                        <property name="selection-mode">none</property>
+                                    <object class="GtkBox">
+                                        <property name="margin-start">12</property>
+                                        <property name="margin-end">12</property>
+                                        <property name="margin-top">12</property>
+                                        <property name="margin-bottom">12</property>
+                                        <property name="spacing">12</property>
+                                        <property name="orientation">vertical</property>
                                         <child>
-                                            <object class="GtkListBoxRow">
-                                                <property name="activatable">0</property>
-                                                <property name="hexpand">1</property>
+                                            <object class="GtkFrame">
                                                 <property name="child">
-                                                    <object class="GtkBox">
-                                                        <property name="margin-start">20</property>
-                                                        <property name="margin-end">20</property>
-                                                        <property name="margin-top">14</property>
-                                                        <property name="spacing">40</property>
-                                                        <property name="margin-bottom">14</property>
-                                                        <property name="hexpand">1</property>
+                                                    <object class="GtkListBox">
+                                                        <property name="selection-mode">none</property>
                                                         <child>
-                                                            <object class="GtkLabel" id="own_fingerprint_label">
-                                                                <property name="halign">start</property>
-                                                                <property name="justify">right</property>
-                                                                <property name="hexpand">1</property>
-                                                            </object>
-                                                        </child>
-                                                        <child>
-                                                            <object class="GtkBox">
-                                                                <property name="hexpand">1</property>
-                                                                <property name="spacing">5</property>
-                                                                <child>
-                                                                    <object class="GtkMenuButton" id="show_qrcode_button">
-                                                                        <property name="icon-name">dino-qr-code-symbolic</property>
-                                                                        <property name="halign">start</property>
-                                                                        <property name="hexpand">1</property>
-                                                                    </object>
-                                                                </child>
-                                                                <child>
-                                                                    <object class="GtkButton" id="copy_button">
-                                                                        <property name="halign">end</property>
-                                                                        <property name="hexpand">1</property>
+                                                            <object class="GtkListBoxRow">
+                                                                <property name="activatable">0</property>
+                                                                <property name="child">
+                                                                    <object class="GtkBox">
+                                                                        <property name="margin-start">20</property>
+                                                                        <property name="margin-end">20</property>
+                                                                        <property name="margin-top">14</property>
+                                                                        <property name="margin-bottom">14</property>
+                                                                        <property name="spacing">40</property>
                                                                         <child>
-                                                                            <object class="GtkImage">
-                                                                                <property name="icon-size">normal</property>
-                                                                                <property name="icon-name">edit-copy-symbolic</property>
+                                                                            <object class="GtkBox">
+                                                                                <property name="orientation">vertical</property>
+                                                                                <property name="hexpand">1</property>
+                                                                                <child>
+                                                                                    <object class="GtkLabel" id="automatically_accept_new_label">
+                                                                                        <property name="halign">start</property>
+                                                                                        <property name="wrap">1</property>
+                                                                                        <attributes>
+                                                                                            <attribute name="scale" value="1.1"></attribute>
+                                                                                        </attributes>
+                                                                                    </object>
+                                                                                </child>
+                                                                                <child>
+                                                                                    <object class="GtkLabel" id="automatically_accept_new_descr">
+                                                                                        <property name="max_width_chars">1</property>
+                                                                                        <property name="hexpand">1</property>
+                                                                                        <property name="vexpand">1</property>
+                                                                                        <property name="xalign">0</property>
+                                                                                        <property name="wrap">1</property>
+                                                                                        <attributes>
+                                                                                            <attribute name="scale" value="0.8"></attribute>
+                                                                                        </attributes>
+                                                                                        <style>
+                                                                                            <class name="dim-label"/>
+                                                                                        </style>
+                                                                                    </object>
+                                                                                </child>
+                                                                            </object>
+                                                                        </child>
+                                                                        <child>
+                                                                            <object class="GtkSwitch" id="auto_accept_switch">
+                                                                                <property name="halign">end</property>
+                                                                                <property name="valign">center</property>
                                                                             </object>
                                                                         </child>
                                                                     </object>
-                                                                </child>
+                                                                </property>
                                                             </object>
                                                         </child>
                                                     </object>
                                                 </property>
                                             </object>
                                         </child>
-                                    </object>
-                                </property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox" id="new_keys_container">
-                        <property name="visible">0</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">2</property>
-                        <child>
-                            <object class="GtkLabel" id="new_keys_label">
-                                <property name="halign">start</property>
-                                <attributes>
-                                    <attribute name="weight" value="PANGO_WEIGHT_BOLD"></attribute>
-                                </attributes>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkFrame">
-                                <property name="child">
-                                    <object class="GtkScrolledWindow">
-                                        <property name="hscrollbar_policy">never</property>
-                                        <property name="propagate_natural_height">1</property>
-                                        <property name="child">
-                                            <object class="GtkListBox" id="new_keys_listbox">
-                                                <property name="selection-mode">none</property>
+                                        <child>
+                                            <object class="GtkBox" id="own_fingerprint_container">
+                                                <property name="visible">0</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="spacing">2</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="own_key_label">
+                                                        <property name="halign">start</property>
+                                                        <attributes>
+                                                            <attribute name="weight" value="PANGO_WEIGHT_BOLD"></attribute>
+                                                        </attributes>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkFrame">
+                                                        <property name="child">
+                                                            <object class="GtkListBox">
+                                                                <property name="selection-mode">none</property>
+                                                                <child>
+                                                                    <object class="GtkListBoxRow">
+                                                                        <property name="activatable">0</property>
+                                                                        <property name="hexpand">1</property>
+                                                                        <property name="child">
+                                                                            <object class="GtkBox">
+                                                                                <property name="margin-start">20</property>
+                                                                                <property name="margin-end">20</property>
+                                                                                <property name="margin-top">14</property>
+                                                                                <property name="spacing">40</property>
+                                                                                <property name="margin-bottom">14</property>
+                                                                                <property name="hexpand">1</property>
+                                                                                <child>
+                                                                                    <object class="GtkLabel" id="own_fingerprint_label">
+                                                                                        <property name="halign">start</property>
+                                                                                        <property name="hexpand">1</property>
+                                                                                        <property name="justify">right</property>
+                                                                                    </object>
+                                                                                </child>
+                                                                                <child>
+                                                                                    <object class="GtkBox">
+                                                                                        <property name="hexpand">1</property>
+                                                                                        <property name="spacing">5</property>
+                                                                                        <child>
+                                                                                            <object class="GtkMenuButton" id="show_qrcode_button">
+                                                                                                <property name="icon-name">dino-qr-code-symbolic</property>
+                                                                                                <property name="halign">start</property>
+                                                                                                <property name="hexpand">1</property>
+                                                                                            </object>
+                                                                                        </child>
+                                                                                        <child>
+                                                                                            <object class="GtkButton" id="copy_button">
+                                                                                                <property name="halign">end</property>
+                                                                                                <property name="hexpand">1</property>
+                                                                                                <child>
+                                                                                                    <object class="GtkImage">
+                                                                                                        <property name="icon-size">normal</property>
+                                                                                                        <property name="icon-name">edit-copy-symbolic</property>
+                                                                                                    </object>
+                                                                                                </child>
+                                                                                            </object>
+                                                                                        </child>
+                                                                                    </object>
+                                                                                </child>
+                                                                            </object>
+                                                                        </property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </property>
+                                                    </object>
+                                                </child>
                                             </object>
-                                        </property>
-                                    </object>
-                                </property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkBox" id="keys_container">
-                        <property name="visible">0</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">2</property>
-                        <child>
-                            <object class="GtkLabel" id="associated_keys_label">
-                                <property name="halign">start</property>
-                                <attributes>
-                                    <attribute name="weight" value="PANGO_WEIGHT_BOLD"></attribute>
-                                </attributes>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkFrame">
-                                <property name="child">
-                                    <object class="GtkScrolledWindow">
-                                        <property name="hscrollbar_policy">never</property>
-                                        <property name="propagate_natural_height">1</property>
-                                        <property name="child">
-                                            <object class="GtkListBox" id="keys_listbox">
-                                                <property name="selection-mode">none</property>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox" id="new_keys_container">
+                                                <property name="visible">0</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="spacing">2</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="new_keys_label">
+                                                        <property name="halign">start</property>
+                                                        <attributes>
+                                                            <attribute name="weight" value="PANGO_WEIGHT_BOLD"></attribute>
+                                                        </attributes>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkFrame">
+                                                        <property name="child">
+                                                            <object class="GtkListBox" id="new_keys_listbox">
+                                                                <property name="selection-mode">none</property>
+                                                            </object>
+                                                        </property>
+                                                    </object>
+                                                </child>
                                             </object>
-                                        </property>
-                                    </object>
-                                </property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkExpander" id="inactive_keys_expander">
-                        <property name="visible">0</property>
-                        <child type="label">
-                            <object class="GtkLabel" id="inactive_expander_label">
-                                <attributes>
-                                    <attribute name="weight" value="PANGO_WEIGHT_BOLD"></attribute>
-                                </attributes>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkFrame">
-                                <property name="margin-top">2</property>
-                                <property name="child">
-                                    <object class="GtkScrolledWindow">
-                                        <property name="hscrollbar_policy">never</property>
-                                        <property name="propagate_natural_height">1</property>
-                                        <property name="child">
-                                            <object class="GtkListBox" id="inactive_keys_listbox">
-                                                <property name="selection-mode">none</property>
+                                        </child>
+                                        <child>
+                                            <object class="GtkBox" id="keys_container">
+                                                <property name="visible">0</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="spacing">2</property>
+                                                <child>
+                                                    <object class="GtkLabel" id="associated_keys_label">
+                                                        <property name="halign">start</property>
+                                                        <attributes>
+                                                            <attribute name="weight" value="PANGO_WEIGHT_BOLD"></attribute>
+                                                        </attributes>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkFrame">
+                                                        <property name="child">
+                                                            <object class="GtkListBox" id="keys_listbox">
+                                                                <property name="selection-mode">none</property>
+                                                            </object>
+                                                        </property>
+                                                    </object>
+                                                </child>
                                             </object>
-                                        </property>
+                                        </child>
+                                        <child>
+                                            <object class="GtkExpander" id="inactive_keys_expander">
+                                                <property name="visible">0</property>
+                                                <child type="label">
+                                                    <object class="GtkLabel" id="inactive_expander_label">
+                                                        <attributes>
+                                                            <attribute name="weight" value="PANGO_WEIGHT_BOLD"></attribute>
+                                                        </attributes>
+                                                    </object>
+                                                </child>
+                                                <child>
+                                                    <object class="GtkFrame">
+                                                        <property name="margin-top">2</property>
+                                                        <property name="child">
+                                                            <object class="GtkListBox" id="inactive_keys_listbox">
+                                                                <property name="selection-mode">none</property>
+                                                            </object>
+                                                        </property>
+                                                    </object>
+                                                </child>
+                                            </object>
+                                        </child>
                                     </object>
-                                </property>
+                                </child>
                             </object>
-                        </child>
+                        </property>
                     </object>
                 </child>
             </object>

--- a/plugins/omemo/data/manage_key_dialog.ui
+++ b/plugins/omemo/data/manage_key_dialog.ui
@@ -119,7 +119,9 @@
                                         <property name="orientation">vertical</property>
                                         <property name="valign">center</property>
                                         <child>
-                                            <object class="GtkImage" id="confirm_image"/>
+                                            <object class="GtkImage" id="confirm_image">
+                                                <property name="icon-size">large</property>
+                                            </object>
                                         </child>
                                         <child>
                                             <object class="GtkLabel" id="confirm_title_label">
@@ -134,7 +136,7 @@
                                                 <property name="wrap">1</property>
                                                 <property name="max-width-chars">40</property>
                                                 <attributes>
-                                                    <attribute name="scale" value="0.8"></attribute>
+                                                    <attribute name="scale" value="1.0"></attribute>
                                                 </attributes>
                                                 <style>
                                                     <class name="dim-label"/>

--- a/plugins/omemo/src/ui/account_settings_entry.vala
+++ b/plugins/omemo/src/ui/account_settings_entry.vala
@@ -47,7 +47,7 @@ public class AccountSettingsEntry : Plugins.AccountSettingsEntry {
             fingerprint.set_markup("%s\n<span font='8'>%s</span>".printf(_("Own fingerprint"), _("Will be generated on first connection")));
         } else {
             string res = fingerprint_markup(fingerprint_from_base64(((!)row)[plugin.db.identity.identity_key_public_base64]));
-            fingerprint.set_markup("%s\n<span font_family='monospace' font='8'>%s</span>".printf(_("Own fingerprint"), res));
+            fingerprint.set_markup("%s\n%s".printf(_("Own fingerprint"), res));
             btn.visible = true;
         }
     }

--- a/plugins/omemo/src/ui/account_settings_entry.vala
+++ b/plugins/omemo/src/ui/account_settings_entry.vala
@@ -9,7 +9,7 @@ public class AccountSettingsEntry : Plugins.AccountSettingsEntry {
 
     private Box box = new Box(Orientation.HORIZONTAL, 0);
     private Label fingerprint = new Label("...") { xalign=0 };
-    private Button btn = new Button.from_icon_name("view-list-symbolic") { has_frame=false, valign=Align.CENTER, visible=false };
+    private Button btn = new Button.from_icon_name("view-list-symbolic") { has_frame=false, margin_start=10, valign=Align.CENTER, visible=false };
 
     public override string id { get { return "omemo_identity_key"; }}
 

--- a/plugins/omemo/src/ui/contact_details_dialog.vala
+++ b/plugins/omemo/src/ui/contact_details_dialog.vala
@@ -303,9 +303,9 @@ public class ContactDetailsDialog : Gtk.Dialog {
 
 public class FingerprintRow : ListBoxRow {
 
-    private Image trust_image = new Image() { visible = true, halign = Align.END };
+    private Image trust_image = new Image() { halign = Align.END };
     private Label fingerprint_label = new Label("") { use_markup=true, justify=Justification.RIGHT, halign = Align.START, valign = Align.CENTER, hexpand = false };
-    private Label trust_label = new Label(null) { visible = true, hexpand = true, xalign = 0 };
+    private Label trust_label = new Label(null) { halign = Align.END, hexpand = true, xalign = 0 };
 
     public Row row;
 

--- a/plugins/omemo/src/ui/contact_details_dialog.vala
+++ b/plugins/omemo/src/ui/contact_details_dialog.vala
@@ -105,7 +105,7 @@ public class ContactDetailsDialog : Gtk.Dialog {
             const int QUIET_ZONE_MODULES = 4;  // MUST be at least 4
             const int MODULE_SIZE_PX = 4;  // arbitrary
             var qr_paintable = new QRcode(iri, 2)
-                .to_paintable(MODULE_SIZE_PX * qrcode_picture.scale_factor);
+                .to_paintable(MODULE_SIZE_PX);
             qrcode_picture.paintable = qr_paintable;
             qrcode_picture.margin_top = qrcode_picture.margin_end =
                     qrcode_picture.margin_bottom = qrcode_picture.margin_start = QUIET_ZONE_MODULES * MODULE_SIZE_PX;

--- a/plugins/omemo/src/ui/util.vala
+++ b/plugins/omemo/src/ui/util.vala
@@ -51,12 +51,13 @@ public static string fingerprint_markup(string s) {
             b = (uint8) (b * factor);
         }
 
-        if (i % 32 == 0 && i != 0) markup += "\n";
+        const int linelen = 16;
+        if (i % linelen == 0 && i != 0) markup += "\n";
         markup += @"<span foreground=\"$("#%02x%02x%02x".printf(r, g, b))\">$four_chars</span>";
-        if (i % 8 == 4 && i % 32 != 28) markup += " ";
+        if (i % 8 == 4 && i % linelen != (linelen - 4)) markup += " ";
     }
 
-    return "<span font_family='monospace' font='8'>" + markup + "</span>";
+    return "<span font_family='monospace' font='10'>" + markup + "</span>";
 }
 
 }


### PR DESCRIPTION
Print OMEMO fingerprints with shorter lines and with a slightly larger font, this makes them fit narrow dialogs and easier to read.

Adapt contact details dialog: Allow resizing, add AdwClamp and replace separate ScrolledWindows by a single whole-dialog scroll area.

Fix various alignment, margin and size issues in OMEMO related UI elements.