### PR TITLE
Use "user-info-symbolic" icon for conversation details button

### DIFF
--- a/main/src/ui/conversation_titlebar/menu_entry.vala
+++ b/main/src/ui/conversation_titlebar/menu_entry.vala
@@ -11,7 +11,7 @@ class MenuEntry : Plugins.ConversationTitlebarEntry, Object {
     StreamInteractor stream_interactor;
     private Conversation? conversation;
 
-    Button button = new Button() { icon_name="view-more-symbolic" };
+    Button button = new Button() { icon_name="user-info-symbolic" };
 
     public MenuEntry(StreamInteractor stream_interactor) {
         this.stream_interactor = stream_interactor;


### PR DESCRIPTION
This icon can be found GNOME's Adwaita Theme which is present in most GNOME desktops by default. ![image](https://github.com/dino/dino/assets/81772782/91d23cbe-7efb-4274-9e61-41bd545d35c3)
Should close https://github.com/dino/dino/issues/1553