### PR TITLE
Fix poor contrast of highlight in messages search results with dark theme

### DIFF
--- a/main/src/ui/global_search.vala
+++ b/main/src/ui/global_search.vala
@@ -260,7 +260,8 @@ public class GlobalSearch {
             for (; match_info.matches(); match_info.next()) {
                 int start, end;
                 match_info.fetch_pos(0, out start, out end);
-                markup_text += Markup.escape_text(text[last_end:start]) + "<span bgcolor=\"yellow\">" + Markup.escape_text(text[start:end]) + "</span>";
+                string themed_span = Util.is_dark_theme(label) ? "<span color=\"black\" bgcolor=\"yellow\">" : "<span bgcolor=\"yellow\">";
+                markup_text += Markup.escape_text(text[last_end:start]) + themed_span + Markup.escape_text(text[start:end]) + "</span>";
                 last_end = end;
             }
             markup_text += Markup.escape_text(text[last_end:text.length]);


### PR DESCRIPTION
Fixes #1308.
From this with dark theme:
![image](https://github.com/dino/dino/assets/81772782/ac9fea22-be2d-443c-8719-c9d770b1c2a0)
to this:
![image](https://github.com/dino/dino/assets/81772782/323615e2-988b-42db-a902-5217e292a971) 