### PR TITLE
Fix malformed message stanzas changing MUC subject

### DIFF
--- a/xmpp-vala/src/module/xep/0045_muc/module.vala
+++ b/xmpp-vala/src/module/xep/0045_muc/module.vala
@@ -285,7 +285,7 @@ public class Module : XmppStreamModule {
     private void on_received_message(XmppStream stream, MessageStanza message) {
         if (message.type_ == MessageStanza.TYPE_GROUPCHAT) {
             StanzaNode? subject_node = message.stanza.get_subnode("subject");
-            if (subject_node != null) {
+            if (subject_node != null && message.body == null){ 
                 string subject = subject_node.get_string_content();
                 stream.get_flag(Flag.IDENTITY).set_muc_subject(message.from, subject);
                 subject_set(stream, subject, message.from);


### PR DESCRIPTION
Hello.

This PR:

- Fixes https://github.com/dino/dino/issues/1542 and thus makes Dino more consistent with https://xmpp.org/extensions/xep-0045.html#enter-subject:
>                    "Note: In accordance with the core definition of XML stanzas,
>                     any message can contain a <subject/> element; only a message that
>                     contains a <subject/> but no <body/> element shall be considered a
>                     subject change for MUC purposes."

- [Threads (XEP-201)](https://xmpp.org/extensions/xep-0201.html) states it can be used to "_Track conversation topics within the context of a one-to-one chat session, a [Multi-User Chat (XEP-0045)](https://xmpp.org/extensions/xep-0045.html) [[4](https://xmpp.org/extensions/xep-0201.html#nt-idm24343607381024)] room, or exchange of normal messages._". We can assume it's an extension of `<body>` and ignore it too.

With this, the following snippet sent from your XML console of choice (Gajim is nice for this) do not change the subject in Dino:
```xml
<message xmlns="jabber:client" to="testmuc@your.muc.domain" type="groupchat">
  <subject>Subject should not be changed to this</subject>
  <body>Testing commit https://github.com/eerielili/dino/commit/42601452efc314e567f377cd704d52f548c0424b</body>
</message>
```
same for:
```xml
<message to='romeo@example.net/orchard' from='juliet@example.com/balcony' id='asiwe8289ljfdalk'
    type='chat'
    xml:lang='en'>
  <subject>Oh tragedy!</subject>
  <body>Art thou not Romeo, and a Montague?</body>
  <thread parent='7edac73ab41e45c4aafa7b2d7b749080'>
    e0ffe42b28561960c6b12b944a092794b9683a38
  </thread>
</message>
```

But the following two can as expected:
```xml
<message xmlns="jabber:client" to="testmuc@your.muc.domain" type="groupchat">
  <subject>Subject should be changed to this</subject>
</message>
```
```xml
<message xmlns="jabber:client" to="testmuc@your.muc.domain" type="groupchat">
  <subject>Subject should be changed to this</subject>
  <delay stamp='2024-03-31T22:00:00Z' xmlns='urn:xmpp:delay' from='testmuc@your.muc.domain' />
</message>
```


Happy Easter to you all!
_eerielili_