### PR TITLE
fix: missing windows icon when running under Wayland

### DIFF
--- a/main/src/ui/application.vala
+++ b/main/src/ui/application.vala
@@ -32,6 +32,7 @@ public class Dino.Ui.Application : Adw.Application, Dino.Application {
         init();
         Environment.set_application_name("Dino");
         Window.set_default_icon_name("im.dino.Dino");
+        GLib.Environment.set_prgname("im.dino.Dino");
 
         create_actions();
         add_main_option_entries(options);


### PR DESCRIPTION
Before:
![Screenshot_20240712_121028](https://github.com/user-attachments/assets/96f3f21a-045b-429f-874a-151d6a1b5aaa)

After:
![Screenshot_20240712_120948](https://github.com/user-attachments/assets/7d494e78-5787-46a5-9170-cbe7ae3e1b91)
