### PR TITLE
Enable setting your own presence

### DIFF
--- a/libdino/src/service/presence_manager.vala
+++ b/libdino/src/service/presence_manager.vala
@@ -77,6 +77,18 @@ public class PresenceManager : StreamInteractionModule, Object {
         if (stream != null) stream.get_module(Xmpp.Presence.Module.IDENTITY).cancel_subscription(stream, jid.bare_jid);
     }
 
+    public void send_presence(string? pres_str){
+            foreach(Account account in stream_interactor.get_accounts()) {
+                XmppStream stream = stream_interactor.get_stream(account);
+                Xmpp.Presence.Stanza presence = new Xmpp.Presence.Stanza();
+                if (pres_str != null) presence.show = pres_str;
+                if (stream != null) {
+                    stream.get_module(Xmpp.Presence.Module.IDENTITY).send_presence(stream, presence);
+                }
+            }
+    }
+
+
     private void on_account_added(Account account) {
         stream_interactor.module_manager.get_module(account, Presence.Module.IDENTITY).received_available_show.connect((stream, jid, show) =>
             on_received_available_show(account, jid, show)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -45,6 +45,7 @@ set(RESOURCE_LIST
     icons/scalable/status/dino-double-tick-symbolic.svg
     icons/scalable/status/dino-party-popper-symbolic.svg
     icons/scalable/status/dino-security-high-symbolic.svg
+    icons/scalable/status/dino-status-xa.svg
     icons/scalable/status/dino-status-away.svg
     icons/scalable/status/dino-status-chat.svg
     icons/scalable/status/dino-status-dnd.svg
@@ -83,6 +84,7 @@ set(RESOURCE_LIST
     conversation_content_view/item_metadata_header.ui
     conversation_content_view/view.ui
     menu_add.ui
+    menu_presence.ui
     menu_app.ui
     menu_conversation.ui
     menu_encryption.ui

--- a/main/data/conversation_list_titlebar.ui
+++ b/main/data/conversation_list_titlebar.ui
@@ -29,5 +29,18 @@
                 </child>
             </object>
         </child>
+        <child type="end">
+            <object class="GtkMenuButton" id="presence_button">
+                <property name="halign">end</property>
+                <property name="hexpand">True</property>
+                <property name="has-frame">False</property>
+                <child>
+                    <object class="GtkImage">
+                        <property name="icon-name">dino-status-chat</property>
+                        <property name="icon-size">normal</property>
+                    </object>
+                </child>
+            </object>
+        </child>
     </object>
 </interface>

--- a/main/data/gresource.xml
+++ b/main/data/gresource.xml
@@ -65,6 +65,7 @@
     <file>join_room_dialog2.ui</file>
     <file>menu_add.ui</file>
     <file>menu_app.ui</file>
+    <file>menu_presence.ui</file>
     <file>menu_conversation.ui</file>
     <file>menu_encryption.ui</file>
     <file>message_item_widget_edit_mode.ui</file>

--- a/main/data/icons/scalable/status/dino-status-xa.svg
+++ b/main/data/icons/scalable/status/dino-status-xa.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="28.222mm" height="28.222mm" version="1.1" viewBox="0 0 99.999997 99.999997" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(-62.857 -678.08)">
+  <circle cx="112.86" cy="728.08" r="50" style="fill-rule:evenodd;fill:#e57373"/>
+ </g>
+</svg>

--- a/main/data/menu_presence.ui
+++ b/main/data/menu_presence.ui
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+    <menu id="menu_presence">
+        <section>
+            <item>
+                <attribute name="action">app.presence_online</attribute>
+                <attribute name="label" translatable="yes">Online</attribute>
+            </item>
+            <item>
+                <attribute name="action">app.presence_dnd</attribute>
+                <attribute name="label" translatable="yes">Do not disturb</attribute>
+            </item>
+            <item>
+                <attribute name="action">app.presence_away</attribute>
+                <attribute name="label" translatable="yes">Away</attribute>
+            </item>
+            <item>
+                <attribute name="action">app.presence_xaway</attribute>
+                <attribute name="label" translatable="yes">Unavailable</attribute>
+            </item>
+        </section>
+    </menu>
+</interface>

--- a/main/src/ui/application.vala
+++ b/main/src/ui/application.vala
@@ -231,6 +231,35 @@ public class Dino.Ui.Application : Adw.Application, Dino.Application {
             call_state.reject();
         });
         add_action(deny_call_action);
+
+        SimpleAction p_online_action = new SimpleAction("presence_online", null);
+        p_online_action.activate.connect( () => {
+            stream_interactor.get_module(PresenceManager.IDENTITY).send_presence(Xmpp.Presence.Stanza.SHOW_ONLINE);
+            window.refresh_presence_button(Xmpp.Presence.Stanza.SHOW_ONLINE);
+        });
+        add_action(p_online_action);
+
+        SimpleAction p_dnd_action = new SimpleAction("presence_dnd", null);
+        p_dnd_action.activate.connect( () => {
+            stream_interactor.get_module(PresenceManager.IDENTITY).send_presence(Xmpp.Presence.Stanza.SHOW_DND);
+            window.refresh_presence_button(Xmpp.Presence.Stanza.SHOW_DND);
+        });
+        add_action(p_dnd_action);
+
+        SimpleAction p_away_action = new SimpleAction("presence_away", null);
+        p_away_action.activate.connect( () => {
+            stream_interactor.get_module(PresenceManager.IDENTITY).send_presence(Xmpp.Presence.Stanza.SHOW_AWAY);
+            window.refresh_presence_button(Xmpp.Presence.Stanza.SHOW_AWAY);
+        });
+        add_action(p_away_action);
+
+        SimpleAction p_xaway_action = new SimpleAction("presence_xaway", null);
+        p_xaway_action.activate.connect( () => {
+            stream_interactor.get_module(PresenceManager.IDENTITY).send_presence(Xmpp.Presence.Stanza.SHOW_XA);
+            window.refresh_presence_button(Xmpp.Presence.Stanza.SHOW_XA);
+        });
+        add_action(p_xaway_action);
+
     }
 
     private void show_preferences_window() {

--- a/main/src/ui/conversation_list_titlebar.vala
+++ b/main/src/ui/conversation_list_titlebar.vala
@@ -4,20 +4,32 @@ using Dino.Entities;
 
 namespace Dino.Ui {
 
-public static Adw.HeaderBar get_conversation_list_titlebar() {
+public static Adw.HeaderBar get_conversation_list_titlebar(string presence = "") {
     Builder builder = new Builder.from_resource("/im/dino/Dino/conversation_list_titlebar.ui");
     MenuButton add_button = (MenuButton) builder.get_object("add_button");
+    MenuButton presence_button = (MenuButton) builder.get_object("presence_button");
     MenuButton menu_button = (MenuButton) builder.get_object("menu_button");
-    create_add_menu(add_button, menu_button);
+    switch(presence) {
+        case Xmpp.Presence.Stanza.SHOW_AWAY: presence_button.set_icon_name("dino-status-away"); break;
+        case Xmpp.Presence.Stanza.SHOW_DND: presence_button.set_icon_name("dino-status-dnd"); break;
+        case Xmpp.Presence.Stanza.SHOW_XA: presence_button.set_icon_name("dino-status-xa"); break;
+        case "offline": presence_button.set_icon_name("dino-status-offline"); break;
+        default: presence_button.set_icon_name("dino-status-online"); break;
+    }
+    create_add_menu(add_button, presence_button, menu_button);
     return (Adw.HeaderBar) builder.get_object("header_bar");
 }
 
-private static void create_add_menu(MenuButton add_button, MenuButton menu_button) {
+private static void create_add_menu(MenuButton add_button, MenuButton presence_button, MenuButton menu_button) {
     add_button.tooltip_text = Util.string_if_tooltips_active(_("Start Conversation"));
 
     Builder add_builder = new Builder.from_resource("/im/dino/Dino/menu_add.ui");
     MenuModel add_menu_model = add_builder.get_object("menu_add") as MenuModel;
     add_button.set_menu_model(add_menu_model);
+
+    Builder presence_builder = new Builder.from_resource("/im/dino/Dino/menu_presence.ui");
+    MenuModel presence_menu_model = presence_builder.get_object("menu_presence") as MenuModel;
+    presence_button.set_menu_model(presence_menu_model);
 
     Builder menu_builder = new Builder.from_resource("/im/dino/Dino/menu_app.ui");
     MenuModel menu_menu_model = menu_builder.get_object("menu_app") as MenuModel;

--- a/main/src/ui/main_window.vala
+++ b/main/src/ui/main_window.vala
@@ -87,6 +87,13 @@ public class MainWindow : Adw.ApplicationWindow {
         conversation_titlebar.back_pressed.connect(() => leaflet.navigate(Adw.NavigationDirection.BACK));
     }
 
+    public void refresh_presence_button(string presence = "") {
+        conversation_list_titlebar.unparent();
+        conversation_list_titlebar = get_conversation_list_titlebar(presence);
+        leaflet.bind_property("folded", conversation_list_titlebar, "show-end-title-buttons", BindingFlags.SYNC_CREATE);
+        left_box.prepend(conversation_list_titlebar);
+    }
+
     private void setup_stack() {
         stack.add_named(box, "main");
         stack.add_named(welcome_placeholder, "welcome_placeholder");

--- a/xmpp-vala/src/module/presence/stanza.vala
+++ b/xmpp-vala/src/module/presence/stanza.vala
@@ -67,6 +67,7 @@ public class Stanza : Xmpp.Stanza {
                 StanzaNode? show_node = stanza.get_subnode(NODE_SHOW);
                 if (show_node == null) {
                     show_node = new StanzaNode.build(NODE_SHOW);
+                    show_node.put_node(new StanzaNode.text(value));
                     stanza.put_node(show_node);
                 }
                 show_node.val = value;


### PR DESCRIPTION
- Added 1 new icon for xa (extended away/unavailable)


Screenshots:
- Online, with dropdown shown:
![image](https://github.com/user-attachments/assets/dab917fe-c03e-4083-9d07-63c238928e65)
- Do not disturb:
![image](https://github.com/user-attachments/assets/3c663594-9e7d-47f9-a356-9eb245681432)
- Away  :
![image](https://github.com/user-attachments/assets/1a76b643-0b02-4d60-b612-07eb8d25473b)
- Extended away :
![image](https://github.com/user-attachments/assets/b5144ebf-77de-4aca-b92a-97872867aa60)

I tested Gajim, Converse and Dino. The presence is well received (one thing to note: in Converse.js, extended away is simply shown as offline).
In dino, one can check it's own presence by adding oneself to chat and hover the row in the left pane. A popup will show:
![image](https://github.com/user-attachments/assets/4edaea1e-8d70-44f3-94f9-51845c1242e2)
