### PR TITLE
Store avatars in the user's cache directory.

### DIFF
--- a/libdino/src/service/avatar_manager.vala
+++ b/libdino/src/service/avatar_manager.vala
@@ -37,8 +37,36 @@ public class AvatarManager : StreamInteractionModule, Object {
     private AvatarManager(StreamInteractor stream_interactor, Database db) {
         this.stream_interactor = stream_interactor;
         this.db = db;
-        this.folder = Path.build_filename(Dino.get_storage_dir(), "avatars");
-        DirUtils.create_with_parents(this.folder, 0700);
+        this.folder = Path.build_filename(Dino.get_cache_dir(), "avatars");
+        string old_avatars_folder = Path.build_filename(Dino.get_storage_dir(), "avatars");
+        if (FileUtils.test(old_avatars_folder, FileTest.IS_DIR)) {
+            if (FileUtils.test(this.folder, FileTest.IS_DIR)){
+                var res = DirUtils.remove(old_avatars_folder);
+                if (res == -1){ // directory not empty
+                    File old_avatars = File.new_for_path(old_avatars_folder);
+                    try {
+                        old_avatars.trash(); // https://specifications.freedesktop.org/trash-spec/latest/
+                        debug("Old avatar folder %s trashed.", old_avatars_folder);
+                    } catch (Error e) {
+                        debug("Error trashing old avatar folder %s: %s\nFalling back to GLib method.", old_avatars_folder, e.message);
+                        Dino.recurse_delete_folder(old_avatars,"",null); // fallback to GLib
+                    }
+                }
+                else {
+                    debug("Old avatar directory %s removed.", old_avatars_folder);
+                }
+            }
+            else{
+                File old_avatars = File.new_for_path(old_avatars_folder);
+                File new_avatars = File.new_for_path(this.folder);
+                DirUtils.create_with_parents(Dino.get_cache_dir(), 0700);
+                old_avatars.move(new_avatars, FileCopyFlags.NONE, null);
+                debug("Avatars directory %s moved to %s", old_avatars_folder, this.folder);
+            }
+        }
+        else {
+            DirUtils.create_with_parents(this.folder, 0700);
+        }
 
         stream_interactor.account_added.connect(on_account_added);
         stream_interactor.module_manager.initialize_account_modules.connect((_, modules) => {

--- a/libdino/src/util/util.vala
+++ b/libdino/src/util/util.vala
@@ -73,34 +73,6 @@ public static string get_cache_dir() {
     return Path.build_filename(Environment.get_user_cache_dir(), "dino");
 }
 
-public void recurse_delete_folder(File file, string space = "", Cancellable? cancellable = null) throws Error {
-	FileEnumerator enumerator = file.enumerate_children (
-		"standard::*",
-		FileQueryInfoFlags.NOFOLLOW_SYMLINKS, 
-		cancellable);
-
-	FileInfo info = null;
-	while (cancellable.is_cancelled () == false && ((info = enumerator.next_file (cancellable)) != null)) {
-		if (info.get_file_type () == FileType.DIRECTORY) {
-			File subdir = file.resolve_relative_path (info.get_name ());
-			recurse_delete_folder(subdir, space + " ", cancellable);
-		} else {
-            FileUtils.remove(file.get_path() + "/" + info.get_name());
-		}
-	}
-    var res = DirUtils.remove(file.get_path());
-    if (res == -1){
-        debug("Error: Folder %s not removed using GLib. Check permissions or ownership ?", file.get_path());
-    }
-    else {
-        debug("Folder %s removed using GLib.", file.get_path());
-    }
-
-	if (cancellable.is_cancelled ()) {
-		throw new IOError.CANCELLED ("I/O Error: Recursive deletion of folder %s was cancelled.", file.get_path());
-	}
-}
-
 [CCode (cname = "dino_gettext", cheader_filename = "dino_i18n.h")]
 public static extern unowned string _(string s);
 

--- a/libdino/src/util/util.vala
+++ b/libdino/src/util/util.vala
@@ -69,6 +69,38 @@ public static string get_storage_dir() {
     return Path.build_filename(Environment.get_user_data_dir(), "dino");
 }
 
+public static string get_cache_dir() {
+    return Path.build_filename(Environment.get_user_cache_dir(), "dino");
+}
+
+public void recurse_delete_folder(File file, string space = "", Cancellable? cancellable = null) throws Error {
+	FileEnumerator enumerator = file.enumerate_children (
+		"standard::*",
+		FileQueryInfoFlags.NOFOLLOW_SYMLINKS, 
+		cancellable);
+
+	FileInfo info = null;
+	while (cancellable.is_cancelled () == false && ((info = enumerator.next_file (cancellable)) != null)) {
+		if (info.get_file_type () == FileType.DIRECTORY) {
+			File subdir = file.resolve_relative_path (info.get_name ());
+			recurse_delete_folder(subdir, space + " ", cancellable);
+		} else {
+            FileUtils.remove(file.get_path() + "/" + info.get_name());
+		}
+	}
+    var res = DirUtils.remove(file.get_path());
+    if (res == -1){
+        debug("Error: Folder %s not removed using GLib. Check permissions or ownership ?", file.get_path());
+    }
+    else {
+        debug("Folder %s removed using GLib.", file.get_path());
+    }
+
+	if (cancellable.is_cancelled ()) {
+		throw new IOError.CANCELLED ("I/O Error: Recursive deletion of folder %s was cancelled.", file.get_path());
+	}
+}
+
 [CCode (cname = "dino_gettext", cheader_filename = "dino_i18n.h")]
 public static extern unowned string _(string s);
 


### PR DESCRIPTION
Closes #1615.
Moreover, this commit separating volatile and less critical media files (avatars in `~/.cache`) and important ones (in `~/.local/share/files`) will make Dino fit more nicely with the [FreeDesktop specifications](https://specifications.freedesktop.org/basedir-spec/latest/index.html#basics) :

- _There is a single base directory relative to which user-specific non-essential (cached) data should be written. This directory is defined by the environment variable $XDG_CACHE_HOME._ 