### PR TITLE
fix: Query duplication in global message search (#1636)

### DIFF
--- a/main/src/ui/global_search.vala
+++ b/main/src/ui/global_search.vala
@@ -98,6 +98,8 @@ public class GlobalSearch {
     }
 
     private void on_key_released(uint keyval, uint keycode, Gdk.ModifierType state) {
+        if (!auto_complete_overlay.visible) return;
+
         if (keyval == Gdk.Key.Return) {
             auto_complete_list.get_selected_row().activate();
         }


### PR DESCRIPTION
Closes #1636.
The only behavior that this commit do not fix is when you do the following upon opening global message search:

- BackSpace
- Ctrl+A
- BackSpace to delete
- Press Enter

It'll still set the search field to `in:x@x` or `with:x@x` depending on the current chat type (groupchat or not). In my opinion, it's really not so bad.