### PR TITLE
Dont send client name stanza to other clients

### DIFF
--- a/xmpp-vala/src/module/presence/flag.vala
+++ b/xmpp-vala/src/module/presence/flag.vala
@@ -35,6 +35,8 @@ public class Flag : XmppStreamFlag {
     }
 
     public void add_presence(Presence.Stanza presence) {
+        // Ensure client name is not added
+        presence.stanza.remove_subnode("client-name");
         if (!resources.has_key(presence.from)) {
             resources[presence.from] = new ArrayList<Jid>(Jid.equals_func);
         }


### PR DESCRIPTION
## Modify`flag.vala` to avoid adding client name in presence stanzas:

These changes ensure that the client name is not included in the presence stanzas sent to other clients, while still maintaining the functionality to show if you are online.