### PR TITLE
p/rtp: do not keep around and reuse GstPipeline

### DIFF
--- a/plugins/rtp/src/plugin.vala
+++ b/plugins/rtp/src/plugin.vala
@@ -269,6 +269,9 @@ public class Dino.Plugins.Rtp.Plugin : RootInterface, VideoCallPlugin, Object {
     public void close_stream(Stream stream) {
         streams.remove(stream);
         stream.destroy();
+        if (streams.is_empty) {
+            destroy_call_pipe();
+        }
     }
 
     public void shutdown() {


### PR DESCRIPTION
When the first call is made a GstPipeline is created and kept around even once the call has ended. If the system is then suspended for some time the timing of that idle GstPipeline gets messed up. If later another call comes in it can take from a few seconds up to a minute for audio to be played back without hiccups. The pacing of the incoming RTP packets looks good and no different from when it later starts working. This reproduces on multiple different system types.

Fix this by tearing down the GstPipeline once the last stream is gone. I've been running this patch on multiple systems for some time and it has completely resolved the issue.

Likely fixes #1451 #1092 and maybe some others.