### PR TITLE
Update copyright year in "About Dino" 

### DIFF
--- a/main/src/ui/application.vala
+++ b/main/src/ui/application.vala
@@ -283,7 +283,7 @@ public class Dino.Ui.Application : Adw.Application, Dino.Application {
         about_window.title = _("About Dino");
         about_window.version = version;
         about_window.website = "https://dino.im/";
-        about_window.copyright = "Copyright © 2016-2023 - Dino Team";
+        about_window.copyright = "Copyright © 2016-2025 - Dino Team";
         about_window.license_type = License.GPL_3_0;
         about_window.present();
     }


### PR DESCRIPTION
This PR updates the year in the "About Dino" section, changing 2023 to 2025.

Not a big change, but hey, it's something! 😉

![250313_15h00m04s_screenshot](https://github.com/user-attachments/assets/b164c613-c859-4e9c-aba0-c55d6d7b46eb)
