### PR TITLE
Gray out avatars of counterparts that are offline.

### DIFF
--- a/main/data/style.css
+++ b/main/data/style.css
@@ -129,6 +129,10 @@ picture.avatar {
     border-radius: 3px;
 }
 
+picture.avatar .unavailable {
+    filter: grayscale(100%);
+}
+
 /* Overlay Toolbar */
 
 .overlay-toolbar {


### PR DESCRIPTION
Grayscaling avatars of offline conversation counterparts has existed until a rewrite in commit db3b0d5f233ee3587ae54f8f035222cb098b11dd, where it was removed without any mention. This PR attempts to fix #1612.

I tried to reintroduce the feature, but as I’m new to Vala and the Dino source code, there are probably much better ways to implement it, and I’ld be happy to change the PR accordingly. I wouldn’t be surprised if there also are unintended side effects that need to be addressed.