### PR TITLE
Use the same path for the meson plugin install directory and Dino’s plugin search path.

### DIFF
--- a/libdino/meson.build
+++ b/libdino/meson.build
@@ -78,7 +78,7 @@ sources = files(
 sources += [version_vala]
 c_args = [
     '-DDINO_SYSTEM_LIBDIR_NAME="@0@"'.format(get_option('prefix') / get_option('libdir')),
-    '-DDINO_SYSTEM_PLUGIN_DIR="@0@"'.format(get_option('prefix') / get_option('plugindir')),
+    '-DDINO_SYSTEM_PLUGIN_DIR="@0@"'.format(installdir_plugins),
     '-DG_LOG_DOMAIN="libdino"',
 ]
 vala_args = []

--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,8 @@ endif
 prog_git = find_program('git', required: false)
 prog_python = python.find_installation()
 
+installdir_plugins = get_option('libdir') / 'dino/plugins'
+
 subdir('qlite')
 subdir('xmpp-vala')
 subdir('libdino')

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,7 @@ endif
 prog_git = find_program('git', required: false)
 prog_python = python.find_installation()
 
-installdir_plugins = get_option('libdir') / 'dino/plugins'
+installdir_plugins = get_option('prefix') / get_option('libdir') / 'dino/plugins'
 
 subdir('qlite')
 subdir('xmpp-vala')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,3 @@
-option('plugindir', type: 'string', value: 'lib/dino/plugins', description: 'Dino plugin directory')
-
 option('plugin-http-files', type: 'feature', description: 'HTTP file upload')
 option('plugin-ice', type: 'feature', description: 'Peer-to-peer communication')
 option('plugin-omemo', type: 'feature', description: 'End-to-end encryption using OMEMO')

--- a/plugins/http-files/meson.build
+++ b/plugins/http-files/meson.build
@@ -18,6 +18,6 @@ sources = files(
 vala_args = [
     '-D', 'SOUP_3_0',
 ]
-lib_http_files = shared_library('http-files', sources, name_prefix: '', vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / 'dino/plugins')
+lib_http_files = shared_library('http-files', sources, name_prefix: '', vala_args: vala_args, dependencies: dependencies, install: true, install_dir: installdir_plugins)
 dep_http_files = declare_dependency(link_with: lib_http_files, include_directories: include_directories('.'))
 summary('HTTP file upload (http-files)', dep_http_files, section: 'Plugins')

--- a/plugins/ice/meson.build
+++ b/plugins/ice/meson.build
@@ -24,6 +24,6 @@ c_args = [
 vala_args = [
     '--vapidir', meson.current_source_dir() / 'vapi',
 ]
-lib_ice = shared_library('ice', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / 'dino/plugins')
+lib_ice = shared_library('ice', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, dependencies: dependencies, install: true, install_dir: installdir_plugins)
 dep_ice = declare_dependency(link_with: lib_ice, include_directories: include_directories('.'))
 summary('Peer-to-peer communication (ice)', dep_ice, section: 'Plugins')

--- a/plugins/notification-sound/meson.build
+++ b/plugins/notification-sound/meson.build
@@ -15,6 +15,6 @@ sources = files(
 vala_args = [
     '--vapidir', meson.current_source_dir() / 'vapi',
 ]
-lib_notification_sound = shared_library('notification-sound', sources, name_prefix: '', vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / 'dino/plugins')
+lib_notification_sound = shared_library('notification-sound', sources, name_prefix: '', vala_args: vala_args, dependencies: dependencies, install: true, install_dir: installdir_plugins)
 dep_notification_sound = declare_dependency(link_with: lib_notification_sound, include_directories: include_directories('.'))
 summary('Sound for chat notifications (notification-sound)', dep_notification_sound, section: 'Plugins')

--- a/plugins/omemo/meson.build
+++ b/plugins/omemo/meson.build
@@ -69,7 +69,7 @@ vala_args = [
     '--internal-vapi', meson.current_build_dir() / 'omemo-internal.vapi',
     '--internal-header', meson.current_build_dir() / 'omemo-internal.h',
 ]
-lib_omemo = shared_library('omemo', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / 'dino/plugins')
+lib_omemo = shared_library('omemo', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: installdir_plugins)
 dep_omemo = declare_dependency(link_with: lib_omemo, include_directories: include_directories('.'))
 summary('End-to-end encryption using OMEMO (omemo)', dep_omemo, section: 'Plugins')
 # This is to use the internal vapi instead of the regular

--- a/plugins/openpgp/meson.build
+++ b/plugins/openpgp/meson.build
@@ -43,6 +43,6 @@ vala_args = [
 if dep_libadwaita.version() == 'unknown' or dep_libadwaita.version().version_compare('>=1.4')
     vala_args += ['-D', 'Adw_1_4']
 endif
-lib_openpgp = shared_library('openpgp', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / 'dino/plugins')
+lib_openpgp = shared_library('openpgp', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: installdir_plugins)
 dep_openpgp = declare_dependency(link_with: lib_openpgp, include_directories: include_directories('.'))
 summary('End-to-end encryption using PGP (openpgp)', dep_openpgp, section: 'Plugins')

--- a/plugins/rtp/meson.build
+++ b/plugins/rtp/meson.build
@@ -79,7 +79,7 @@ if get_option('plugin-rtp-vp9').allowed()
     vala_args += ['-D', 'ENABLE_VP9']
 endif
 
-lib_rtp = shared_library('rtp', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / 'dino/plugins')
+lib_rtp = shared_library('rtp', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: installdir_plugins)
 dep_rtp = declare_dependency(link_with: lib_rtp, include_directories: include_directories('.'))
 summary('Voice/video calls (rtp)', dep_rtp, section: 'Plugins')
 


### PR DESCRIPTION
Before the change, the plugin install directories were determined by the `libdir` option value prepended to the hardcoded path `dino/plugins`, whereas Dino’s search path for plugins was determined by the `prefix` option value prepended to the `plugindir` option value (by default `lib/dino/plugins`).
I encountered this issue when I created an RPM spec file for openSUSE Tumbleweed that builds with meson instead of cmake. The default meson setup macro sets `--libdir=/usr/lib64`, but the `plugindir` value is not automatically updated and thus Dino installed from the generated package could not find the plugins.

As part of the fix, I took the liberty of removing the `plugindir` option.