### PR TITLE
Add minimal .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.vala]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
.editorconfig is read by some editors to automatically set indentation settings. For now, I've set it to use 4-space indentation in .vala files.