### PR TITLE
Optionally use libsecret to store the password

### DIFF
--- a/libdino/meson.build
+++ b/libdino/meson.build
@@ -85,6 +85,11 @@ vala_args = []
 if meson.get_compiler('vala').version().version_compare('=0.56.11')
     vala_args += ['-D', 'VALA_0_56_11']
 endif
+if get_option('plugin-secret').allowed()
+    vala_args += ['-D', 'WITH_SECRET']
+    dependencies += [dep_secret]
+    sources += ['src/service/secret_manager.vala']
+endif
 lib_dino = library('libdino', sources, c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, name_prefix: '', version: '0.0', install: true, install_dir: [true, true, true], install_rpath: default_install_rpath)
 dep_dino = declare_dependency(link_with: lib_dino, include_directories: include_directories('.', 'src'))
 

--- a/libdino/src/service/module_manager.vala
+++ b/libdino/src/service/module_manager.vala
@@ -34,9 +34,7 @@ public class ModuleManager {
 
         foreach (XmppStreamModule module in module_map[account]) {
             if (module.get_id() == Bind.Module.IDENTITY.id) {
-                ((Bind.Module) module).requested_resource = account.resourcepart;
-            } else if (module.get_id() == Sasl.Module.IDENTITY.id) {
-                ((Sasl.Module) module).password = account.password;
+                (module as Bind.Module).requested_resource = account.resourcepart;
             }
         }
         return modules;
@@ -46,7 +44,7 @@ public class ModuleManager {
         lock(module_map) {
             module_map[account] = new ArrayList<XmppStreamModule>();
             module_map[account].add(new Iq.Module());
-            module_map[account].add(new Sasl.Module(account.bare_jid.to_string(), account.password));
+            module_map[account].add(new Sasl.Module(account.bare_jid.to_string(), account));
             module_map[account].add(new Xep.StreamManagement.Module());
             module_map[account].add(new Bind.Module(account.resourcepart));
             module_map[account].add(new Session.Module());

--- a/libdino/src/service/registration.vala
+++ b/libdino/src/service/registration.vala
@@ -27,7 +27,7 @@ public class Register : StreamInteractionModule, Object{
 
         Gee.List<XmppStreamModule> list = new ArrayList<XmppStreamModule>();
         list.add(new Iq.Module());
-        list.add(new Sasl.Module(account.bare_jid.to_string(), account.password));
+        list.add(new Sasl.Module(account.bare_jid.to_string(), account));
 
         XmppStreamResult stream_result = yield Xmpp.establish_stream(account.bare_jid.domain_jid, list, Application.print_xmpp,
                 (peer_cert, errors) => { return ConnectionManager.on_invalid_certificate(account.domainpart, peer_cert, errors); }

--- a/libdino/src/service/secret_manager.vala
+++ b/libdino/src/service/secret_manager.vala
@@ -1,0 +1,48 @@
+#if WITH_SECRET
+using Secret;
+
+using Xmpp;
+using Dino.Entities;
+
+namespace Dino {
+
+public class SecretManager {
+
+    private string user;
+    private string server;
+    private static Secret.Schema schema = new Secret.Schema("org.gnome.keyring.NetworkPassword", Secret.SchemaFlags.NONE,
+                                                            "user", Secret.SchemaAttributeType.STRING,
+                                                            "server", Secret.SchemaAttributeType.STRING,
+                                                            "protocol", Secret.SchemaAttributeType.STRING);
+
+    public SecretManager(Jid jid) {
+        user = jid.localpart;
+        server = jid.domainpart;
+    }
+
+    public async string? get_password() {
+        try {
+            return yield Secret.password_lookup(schema, null,
+                                               "user", user,
+                                               "server", server,
+                                               "protocol", "xmpp");
+        } catch (GLib.Error e) {
+            return null;
+        }
+    }
+
+    public async bool set_password(string password) {
+        try {
+            return yield Secret.password_store(schema, Secret.COLLECTION_DEFAULT,
+                                       "XMPP account " + user + "@" + server, password, null,
+                                       "user", user,
+                                       "server", server,
+                                       "protocol", "xmpp");
+        } catch (GLib.Error e) {
+            return false;
+        }
+    }
+}
+
+}
+#endif

--- a/main/src/ui/util/label_hybrid.vala
+++ b/main/src/ui/util/label_hybrid.vala
@@ -9,6 +9,10 @@ public class LabelHybrid : Widget {
     public Label label = new Label("") { max_width_chars=1, ellipsize=Pango.EllipsizeMode.END };
     protected Button button = new Button() { has_frame=false };
 
+    public signal void switched_to_label();
+    public signal void switched_to_widget();
+    private bool shows_widget = false;
+
     internal virtual void init(Widget widget) {
         this.layout_manager = new BinLayout();
         stack.set_parent(this);
@@ -24,10 +28,18 @@ public class LabelHybrid : Widget {
     public void show_widget() {
         stack.visible_child_name = "widget";
         stack.get_child_by_name("widget").grab_focus();
+        if (!shows_widget) {
+            switched_to_widget();
+            shows_widget = true;
+        }
     }
 
     public void show_label() {
         stack.visible_child_name = "label";
+        if (shows_widget) {
+            switched_to_label();
+            shows_widget = false;
+        }
     }
 
     public override void dispose() {

--- a/main/src/view_model/preferences_window.vala
+++ b/main/src/view_model/preferences_window.vala
@@ -121,7 +121,7 @@ public class Dino.Ui.ViewModel.ChangePasswordDialog : Object {
     public async string? change_password(string new_password) {
         var res = yield stream_interactor.get_module(Register.IDENTITY).change_password(account, new_password);
         if (res == null) {
-            account.password = new_password;
+            account.set_password(new_password);
         }
         return res;
     }

--- a/main/src/windows/preferences_window/account_preferences_subpage.vala
+++ b/main/src/windows/preferences_window/account_preferences_subpage.vala
@@ -62,8 +62,12 @@ public class Dino.Ui.AccountPreferencesSubpage : Gtk.Box {
             var password = new PasswordEntry() { show_peek_icon=true };
             dialog.response.connect((response) => {
                 if (response == "connect") {
-                    account.password = password.text;
-                    model.reconnect_account(account);
+                    var new_pw = password.text;
+
+                    // TODO indicate saving?
+                    account.set_password.begin(new_pw, (obj, res) => {
+                        model.reconnect_account(account);
+                    });
                 }
             });
             dialog.set_default_response("connect");

--- a/main/src/windows/preferences_window/add_account_dialog.vala
+++ b/main/src/windows/preferences_window/add_account_dialog.vala
@@ -211,7 +211,8 @@ public class AddAccountDialog : Adw.Window {
             if (password_group.visible) {
                 // JID + Psw fields were visible: Try to log in
                 string password = password_entry.text;
-                Account account = new Account(login_jid, password);
+                Account account = new Account(login_jid);
+                yield account.set_password(password);
 
                 ConnectionManager.ConnectionError.Source? error = yield stream_interactor.get_module(Register.IDENTITY).add_check_account(account);
                 sign_in_continue_spinner.visible = false;

--- a/main/src/windows/preferences_window/change_password_dialog.vala
+++ b/main/src/windows/preferences_window/change_password_dialog.vala
@@ -46,7 +46,9 @@ namespace Dino.Ui{
             string? pw_input = current_password_entry.get_text();
             string? new_pw_input = new_password_entry.get_text();
 
-            if (pw_input != null && model.account.password == pw_input){
+            var password = yield model.account.get_password();
+
+            if (pw_input != null && password == pw_input){
                 change_password_button.sensitive = false;
                 change_password_stack.visible_child_name = "spinner";
                 string? ret = yield model.change_password(new_pw_input);

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,7 @@ dep_libomemo_c = dependency('libomemo-c', disabler: true, required: get_option('
 dep_libsoup = dependency('libsoup-3.0', disabler: true, required: get_option('plugin-http-files'))
 dep_nice = dependency('nice', version: '>=0.1.15', disabler: true, required: get_option('plugin-ice'))
 dep_m = meson.get_compiler('c').find_library('m', required: false)
+dep_secret = dependency('libsecret-1', disabler: true, required: get_option('plugin-secret'))
 dep_sqlite3 = dependency('sqlite3', version: '>=3.24')
 
 dep_webrtc_audio_processing = dependency('webrtc-audio-processing-1', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,7 @@ option('plugin-omemo', type: 'feature', description: 'End-to-end encryption usin
 option('plugin-openpgp', type: 'feature', description: 'End-to-end encryption using PGP')
 option('plugin-rtp', type: 'feature', description: 'Voice/video calls')
 option('plugin-notification-sound', type: 'feature', value: 'disabled', description: 'Sound for chat notifications')
+option('plugin-secret', type: 'feature', value: 'disabled', description: 'Password storage via libsecret')
 
 option('plugin-rtp-h264', type: 'feature', value: 'disabled', description: 'H264 codec')
 option('plugin-rtp-msdk', type: 'feature', value: 'disabled', description: 'Intel MediaSDK')


### PR DESCRIPTION
Continuation of #254, updated for compatibility with latest master and to fix clearing the plaintext password on migration.

If compiled with -Dplugin-secret=enabled, Dino will now use the system secret store to save passwords instead of saving them in its own database.

Fixes #102.