### PR TITLE
device: Request 30 fps in absence of framerate negotiation

### DIFF
--- a/plugins/rtp/src/device.vala
+++ b/plugins/rtp/src/device.vala
@@ -418,6 +418,11 @@ public class Dino.Plugins.Rtp.Device : MediaDevice, Object {
             Value? framerate = that.get_value("framerate");
             if (framerate != null && framerate.type() == typeof(Gst.ValueList) && best_fraction != null) {
                 that.set_value("framerate", best_fraction);
+            } else if (framerate == null) {
+                // The source does not support framerate negotiation. Just set a
+                // reasonable value. The source might be able to honor it and
+                // should ignore it otherwise.
+                that.@set("framerate", typeof(Gst.Fraction), 30, 1, null);
             }
             debug("Selected caps %s", res.to_string());
             return res;


### PR DESCRIPTION
Sources not capable of negotiating framerates, most notably the libcamera Pipewire plugin, might still be able to honor a value requested and otherwise usually just ignore it.

Thus setting a value that we can reasonably assume to be supported has several benefits:
1. It potentially prevents the source from producing much higher fps than useful for the usecase, causing resource waste.
2. It decreases the chances of running into fallback code paths which are often badly optimized performance-wise. One example is that currently the implicitly set framerate values cause regular renegotiations (including buffer re-allocations) in pipewiresrc. Another is the internal get_target_bitrate(), currently returning uint.MAX.
3. If the source can only produce e.g. 15 fps, that's usually handled without major issues.

Thus follow the example of Snapshot, which has been doing this for a while and gets more testing with libcamera, and set framerate to 30/1.

---

Related to https://github.com/dino/dino/pull/1737 and https://github.com/dino/dino/pull/1736