### PR TITLE
rtp: device: Ensure even heights for rescaled streams

### DIFF
--- a/plugins/rtp/src/device.vala
+++ b/plugins/rtp/src/device.vala
@@ -218,6 +218,9 @@ public class Dino.Plugins.Rtp.Device : MediaDevice, Object {
         }
         if (new_width == active_caps_width) return;
         int new_height = device_caps_height * new_width / device_caps_width;
+        if ((new_height % 2) != 0) {
+            new_height += 1;
+        }
         Gst.Caps new_caps;
         if (device_caps_framerate_den != 0) {
             new_caps = new Gst.Caps.simple("video/x-raw", "width", typeof(int), new_width, "height", typeof(int), new_height, "framerate", typeof(Gst.Fraction), device_caps_framerate_num, device_caps_framerate_den, null);


### PR DESCRIPTION
Odd heights, while generally handled by Gstreamer, can cause issues in
various places - most importantly hardware video en-/decoders and
GL/VK drivers - as in most cases 2x0 or 2x2 subsampled intermediate
pixel formats are used (such as I420, YUYV, NV12 etc.).

---

cc @mar-v-in - this may help with issues you've been observing around hardware en-/decoders.

Related:
 - https://github.com/dino/dino/pull/1738