### PR TITLE
Various improvement and cleanups for video codecs/calls

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,7 +11,7 @@ option('plugin-notification-sound', type: 'feature', value: 'disabled', descript
 
 option('plugin-rtp-h264', type: 'feature', value: 'disabled', description: 'H264 codec')
 option('plugin-rtp-msdk', type: 'feature', value: 'disabled', description: 'Intel MediaSDK')
-option('plugin-rtp-vaapi', type: 'feature', value: 'disabled', description: 'Video Acceleration API')
+option('plugin-rtp-vaapi', type: 'feature', value: 'auto', description: 'Video Acceleration API')
 option('plugin-rtp-vp9', type: 'feature', value: 'disabled', description: 'VP9 codec')
 option('plugin-rtp-v4l2', type: 'feature', value: 'disabled', description: 'V4L2 API (stateful)')
 option('plugin-rtp-v4l2-sl', type: 'feature', value: 'disabled', description: 'V4L2 API (stateless)')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,4 +13,6 @@ option('plugin-rtp-h264', type: 'feature', value: 'disabled', description: 'H264
 option('plugin-rtp-msdk', type: 'feature', value: 'disabled', description: 'Intel MediaSDK')
 option('plugin-rtp-vaapi', type: 'feature', value: 'disabled', description: 'Video Acceleration API')
 option('plugin-rtp-vp9', type: 'feature', value: 'disabled', description: 'VP9 codec')
+option('plugin-rtp-v4l2', type: 'feature', value: 'disabled', description: 'V4L2 API (stateful)')
+option('plugin-rtp-v4l2-sl', type: 'feature', value: 'disabled', description: 'V4L2 API (stateless)')
 option('plugin-rtp-webrtc-audio-processing', value: 'auto', type: 'feature', description: 'Voice preprocessing')

--- a/plugins/rtp/meson.build
+++ b/plugins/rtp/meson.build
@@ -79,6 +79,16 @@ if get_option('plugin-rtp-vp9').allowed()
     vala_args += ['-D', 'ENABLE_VP9']
 endif
 
+option_v4l2_enabled = get_option('plugin-rtp-v4l2').enabled()
+if option_v4l2_enabled
+    vala_args += ['-D', 'ENABLE_V4L2']
+endif
+
+option_v4l2_sl_enabled = get_option('plugin-rtp-v4l2-sl').enabled()
+if option_v4l2_sl_enabled
+    vala_args += ['-D', 'ENABLE_V4L2SL']
+endif
+
 lib_rtp = shared_library('rtp', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
 dep_rtp = declare_dependency(link_with: lib_rtp, include_directories: include_directories('.'))
 summary('Voice/video calls (rtp)', dep_rtp.found(), bool_yn: true, section: 'Plugins')
@@ -88,5 +98,7 @@ if dep_rtp.found()
     summary('VP9 codec', get_option('plugin-rtp-vp9').allowed(), section: 'RTP configuration')
     summary('Intel MediaSDK', get_option('plugin-rtp-msdk').allowed(), section: 'RTP configuration')
     summary('Video Acceleration API', get_option('plugin-rtp-vaapi').allowed(), section: 'RTP configuration')
+    summary('V4L2 API (stateful)', option_v4l2_enabled, section: 'RTP configuration')
+    summary('V4L2 API (stateless)', option_v4l2_sl_enabled, section: 'RTP configuration')
     summary('Voice preprocessing', dep_webrtc_audio_processing.found(), section: 'RTP configuration')
 endif

--- a/plugins/rtp/meson.build
+++ b/plugins/rtp/meson.build
@@ -72,7 +72,8 @@ endif
 if get_option('plugin-rtp-msdk').allowed()
     vala_args += ['-D', 'ENABLE_MSDK']
 endif
-if get_option('plugin-rtp-vaapi').allowed()
+option_vaapi_enabled = get_option('plugin-rtp-vaapi').enabled() or (get_option('plugin-rtp-vaapi').allowed() and dep_gstreamer_rtp.version().version_compare('>=1.28'))
+if option_vaapi_enabled
     vala_args += ['-D', 'ENABLE_VAAPI']
 endif
 if get_option('plugin-rtp-vp9').allowed()
@@ -97,7 +98,7 @@ if dep_rtp.found()
     summary('H264 codec', get_option('plugin-rtp-h264').allowed(), section: 'RTP configuration')
     summary('VP9 codec', get_option('plugin-rtp-vp9').allowed(), section: 'RTP configuration')
     summary('Intel MediaSDK', get_option('plugin-rtp-msdk').allowed(), section: 'RTP configuration')
-    summary('Video Acceleration API', get_option('plugin-rtp-vaapi').allowed(), section: 'RTP configuration')
+    summary('Video Acceleration API', option_vaapi_enabled, section: 'RTP configuration')
     summary('V4L2 API (stateful)', option_v4l2_enabled, section: 'RTP configuration')
     summary('V4L2 API (stateless)', option_v4l2_sl_enabled, section: 'RTP configuration')
     summary('Voice preprocessing', dep_webrtc_audio_processing.found(), section: 'RTP configuration')

--- a/plugins/rtp/src/codec_util.vala
+++ b/plugins/rtp/src/codec_util.vala
@@ -102,7 +102,8 @@ public class Dino.Plugins.Rtp.CodecUtil {
                         "msdkh264enc",
 #endif
 #if ENABLE_VAAPI
-                        "vaapih264enc",
+                        "vah264lpenc",
+                        "vah264enc",
 #endif
                         "x264enc"
                     };
@@ -112,7 +113,8 @@ public class Dino.Plugins.Rtp.CodecUtil {
                         "msdkvp9enc",
 #endif
 #if ENABLE_VAAPI
-                        "vaapivp9enc",
+                        "vavp9lpenc",
+                        "vavp9enc",
 #endif
                         "vp9enc"
                     };
@@ -122,7 +124,8 @@ public class Dino.Plugins.Rtp.CodecUtil {
                         "msdkvp8enc",
 #endif
 #if ENABLE_VAAPI
-                        "vaapivp8enc",
+                        "vavp8lpenc",
+                        "vavp8enc",
 #endif
                         "vp8enc"
                     };
@@ -154,7 +157,7 @@ public class Dino.Plugins.Rtp.CodecUtil {
                         "msdkh264dec",
 #endif
 #if ENABLE_VAAPI
-                        "vaapih264dec",
+                        "vah264dec",
 #endif
                         null
                     };
@@ -164,7 +167,7 @@ public class Dino.Plugins.Rtp.CodecUtil {
                         "msdkvp9dec",
 #endif
 #if ENABLE_VAAPI
-                        "vaapivp9dec",
+                        "vavp9dec",
 #endif
                         "vp9dec"
                     };
@@ -174,7 +177,7 @@ public class Dino.Plugins.Rtp.CodecUtil {
                         "msdkvp8dec",
 #endif
 #if ENABLE_VAAPI
-                        "vaapivp8dec",
+                        "vavp8dec",
 #endif
                         "vp8dec"
                     };
@@ -185,22 +188,21 @@ public class Dino.Plugins.Rtp.CodecUtil {
 
     public static string? get_encode_prefix(string media, string codec, string encode, JingleRtp.PayloadType? payload_type) {
         if (encode == "msdkh264enc") return "capsfilter caps=video/x-raw,format=NV12 ! ";
-        if (encode == "vaapih264enc") return "capsfilter caps=video/x-raw,format=NV12 ! ";
+        if (encode == "vahvp8lpenc" || encode == "vavp8enc" || encode == "vavp9lpenc" || encode == "vavp9enc" || encode == "vah264lpenc" || encode == "vah264enc") return "capsfilter caps=video/x-raw,format=NV12 ! ";
         return null;
     }
 
     public static string? get_encode_args(string media, string codec, string encode, JingleRtp.PayloadType? payload_type) {
         // H264
-        if (encode == "msdkh264enc") return @" rate-control=vbr";
-        if (encode == "vaapih264enc") return @" rate-control=vbr";
+        if (encode == "msdkh264enc" || encode == "vah264lpenc" || encode == "vah264enc") return @" rate-control=vbr";
         if (encode == "x264enc") return @" byte-stream=1 speed-preset=ultrafast tune=zerolatency bframes=0 cabac=false dct8x8=false";
 
         // VP8
-        if (encode == "vaapivp8enc" || encode == "msdkvp8enc") return " rate-control=vbr target-percentage=90";
+        if (encode == "msdkvp8enc" || encode == "vavp8lpenc" || encode == "vavp8enc") return " rate-control=vbr target-percentage=90";
         if (encode == "vp8enc") return " deadline=1 error-resilient=3 lag-in-frames=0 resize-allowed=true threads=8 dropframe-threshold=30 end-usage=vbr cpu-used=4";
 
         // VP9
-        if (encode == "msdkvp9enc" || encode == "vaapivp9enc") return " rate-control=vbr target-percentage=90";
+        if (encode == "msdkvp9enc" || encode == "vavp9lpenc" || encode == "vavp9enc") return " rate-control=vbr target-percentage=90";
         if (encode == "vp9enc") return " deadline=1 error-resilient=3 lag-in-frames=0 resize-allowed=true threads=8 dropframe-threshold=30 end-usage=vbr cpu-used=4";
 
         // OPUS
@@ -229,12 +231,15 @@ public class Dino.Plugins.Rtp.CodecUtil {
 
         switch (encode_name) {
             case "msdkh264enc":
-            case "vaapih264enc":
+            case "vah264lpenc":
+            case "vah264enc":
             case "x264enc":
             case "msdkvp9enc":
-            case "vaapivp9enc":
+            case "vavp9lpenc":
+            case "vavp9enc":
             case "msdkvp8enc":
-            case "vaapivp8enc":
+            case "vavp8lpenc":
+            case "vavp8enc":
                 bitrate = uint.min(2048000, bitrate);
                 encode.set("bitrate", bitrate);
                 return bitrate;
@@ -265,12 +270,14 @@ public class Dino.Plugins.Rtp.CodecUtil {
     }
 
     public static string? get_decode_prefix(string media, string codec, string decode, JingleRtp.PayloadType? payload_type) {
+        if (decode == "vah264dec") return "h264parse ! ";
+        if (decode == "vavp9dec") return "vp9parse ! ";
         return null;
     }
 
     public static string? get_decode_args(string media, string codec, string decode, JingleRtp.PayloadType? payload_type) {
         if (decode == "opusdec" && payload_type != null && payload_type.parameters.has("useinbandfec", "1")) return " use-inband-fec=true";
-        if (decode == "vaapivp9dec" || decode == "vaapivp8dec" || decode == "vaapih264dec") return " max-errors=100";
+        if (decode == "vavp8dec" || decode == "vavp9dec" || decode == "vah264dec") return " max-errors=100";
         if (decode == "vp8dec" || decode == "vp9dec") return " threads=8";
         return null;
     }

--- a/plugins/rtp/src/codec_util.vala
+++ b/plugins/rtp/src/codec_util.vala
@@ -295,7 +295,7 @@ public class Dino.Plugins.Rtp.CodecUtil {
             supported_elements.add(element_name);
             return true;
         } else {
-            warning("%s is not installed or supported on this system", element_name);
+            info("%s is not installed or supported on this system", element_name);
             unsupported_elements.add(element_name);
             return false;
         }

--- a/plugins/rtp/src/codec_util.vala
+++ b/plugins/rtp/src/codec_util.vala
@@ -159,6 +159,12 @@ public class Dino.Plugins.Rtp.CodecUtil {
 #if ENABLE_VAAPI
                         "vah264dec",
 #endif
+#if ENABLE_V4L2
+                        "v4l2h264dec",
+#endif
+#if ENABLE_V4L2SL
+                        "v4l2slh264dec",
+#endif
                         null
                     };
                 case "vp9":
@@ -169,6 +175,12 @@ public class Dino.Plugins.Rtp.CodecUtil {
 #if ENABLE_VAAPI
                         "vavp9dec",
 #endif
+#if ENABLE_V4L2
+                        "v4l2vp9dec",
+#endif
+#if ENABLE_V4L2SL
+                        "v4l2slvp9dec",
+#endif
                         "vp9dec"
                     };
                 case "vp8":
@@ -178,6 +190,12 @@ public class Dino.Plugins.Rtp.CodecUtil {
 #endif
 #if ENABLE_VAAPI
                         "vavp8dec",
+#endif
+#if ENABLE_V4L2
+                        "v4l2vp8dec",
+#endif
+#if ENABLE_V4L2SL
+                        "v4l2slvp8dec",
 #endif
                         "vp8dec"
                     };
@@ -270,14 +288,14 @@ public class Dino.Plugins.Rtp.CodecUtil {
     }
 
     public static string? get_decode_prefix(string media, string codec, string decode, JingleRtp.PayloadType? payload_type) {
-        if (decode == "vah264dec") return "h264parse ! ";
-        if (decode == "vavp9dec") return "vp9parse ! ";
+        if (decode == "vah264dec" || decode == "v4l2h264dec" || decode == "v4l2slh264dec") return "h264parse ! ";
+        if (decode == "vavp9dec" || decode == "v4l2vp9dec" || decode == "v4l2slvp9dec") return "vp9parse ! ";
         return null;
     }
 
     public static string? get_decode_args(string media, string codec, string decode, JingleRtp.PayloadType? payload_type) {
         if (decode == "opusdec" && payload_type != null && payload_type.parameters.has("useinbandfec", "1")) return " use-inband-fec=true";
-        if (decode == "vavp8dec" || decode == "vavp9dec" || decode == "vah264dec") return " max-errors=100";
+        if (decode == "vavp8dec" || decode == "vavp9dec" || decode == "vah264dec" || decode == "v4l2vp8dec" || decode == "v4l2vp9dec" || decode == "v4l2h264dec" || decode == "v4l2slvp8dec" || decode == "v4l2slvp9dec" || decode == "v4l2slh264dec") return " max-errors=100";
         if (decode == "vp8dec" || decode == "vp9dec") return " threads=8";
         return null;
     }


### PR DESCRIPTION
Inspired by https://github.com/dino/dino/pull/1742 this is a collection of changes that together improve video call quality quite a bit for me - see individual commits.

---

Tested on:
 - ThinkPad P14s Gen 5 AMD, Fedora 43, VA-API encoding+decoding
 - ThinkPad X220 (Intel Sandybridge, from 2011, *1), Fedora 43, VA-API decoding
 - Desktop AMD system, Fedora 43, VA-API encoding+decoding
 - PinePhone Pro, PineBook Pro, Librem5, postmarketOS, V4L2 stateless decoding
 - Fairphone 5, Pixel 3a, OnePlus6, postmarketOS, software encoding and decoding (V4L2 stateful decoding unstable) 

cc @mar-v-in 

Includes:
 - https://github.com/dino/dino/pull/1775

Related:
 - https://github.com/dino/dino/pull/1742
 - https://github.com/dino/dino/pull/1738

---

Notes:
1. On old Intel systems using the derpecated `intel-vaapi-driver` [video encoding is blocklisted](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7170) by Gstreamer for stability reasons. In can be forced-enabled by running with `GST_VA_ALL_DRIVERS=1`, however a quick test on a ThinkPad X220 showed clearly visible glitches/artifacts appearing. *Decoding* with VA-API works just fine though (and is enabled by default by this PR).