### PR TITLE
Set message menu box to be not visible by default (fixes #1745)

### DIFF
--- a/main/data/conversation_content_view/view.ui
+++ b/main/data/conversation_content_view/view.ui
@@ -26,6 +26,7 @@
                                                 <property name="margin-end">10</property>
                                                 <property name="halign">end</property>
                                                 <property name="valign">start</property>
+                                                <property name="visible">False</property>
                                                 <style>
                                                     <class name="card"/>
                                                     <class name="toolbar"/>


### PR DESCRIPTION
This closes #1745.
When Dino is opened and a conversation selected an empty message menu box can be seen like shown in the video [here](https://github.com/dino/dino/issues/1745#issuecomment-3506148273).
This can also happen when first setting up an account and receiving or sending an invite request without sending a message: a conversation pane will open and the ghost menu box is visible, tucked just behind the input text box:
<img width="428" height="219" alt="Image" src="https://github.com/user-attachments/assets/8379d066-1146-4e7b-9d84-b41690580ddc" />

It's happening because the state of `message_menu_box.visible` is true by default, so it can appear on Dino startup / first convo in a not initialized form (no reply or message correction or emoji icon, etc).
Setting `message_menu_box.visible = false` at the end of the constructor fixes the issue.