### PR TITLE
po: complete the Czech translation

### DIFF
--- a/main/po/cs.po
+++ b/main/po/cs.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-10-13 21:57+0200\n"
-"PO-Revision-Date: 2023-05-19 07:48+0000\n"
+"PO-Revision-Date: 2025-11-22 16:50+0100\n"
 "Language-Team: none\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"X-Generator: Weblate 4.18-dev\n"
+"X-Generator: Poedit 3.7\n"
 
 #: main/src/windows/preferences_window/account_preferences_subpage.vala:64
 #: main/src/windows/preferences_window/account_preferences_subpage.vala:131
@@ -38,11 +38,11 @@ msgstr "Připojit"
 #: main/src/windows/preferences_window/account_preferences_subpage.vala:87
 #: main/data/preferences_window/account_preferences_subpage.ui:125
 msgid "Disable account"
-msgstr ""
+msgstr "Deaktivovat účet"
 
 #: main/src/windows/preferences_window/account_preferences_subpage.vala:87
 msgid "Enable account"
-msgstr ""
+msgstr "Aktivovat účet"
 
 #: main/src/windows/preferences_window/account_preferences_subpage.vala:131
 msgid "Select avatar"
@@ -102,7 +102,7 @@ msgstr "Účty"
 
 #: main/src/windows/preferences_window/accounts_preferences_page.vala:28
 msgid "Disabled accounts"
-msgstr ""
+msgstr "Deaktivované účty"
 
 #: main/src/windows/preferences_window/accounts_preferences_page.vala:31
 #: main/src/windows/preferences_window/add_account_dialog.vala:81
@@ -203,31 +203,31 @@ msgstr "Podívejte se na %s pro získání informací ohledně způsobu přihlá
 
 #: main/src/windows/conversation_details.vala:76
 msgid "Block user"
-msgstr ""
+msgstr "Zablokovat uživatele"
 
 #: main/src/windows/conversation_details.vala:76
 msgid "Block entire domain"
-msgstr ""
+msgstr "Zablokovat celou doménu"
 
 #: main/src/windows/conversation_details.vala:76
 msgid "Unblock"
-msgstr ""
+msgstr "Odblokovat"
 
 #: main/src/windows/conversation_details.vala:93
 msgid "Pinned"
-msgstr ""
+msgstr "Připnuto"
 
 #: main/src/windows/conversation_details.vala:93
 msgid "Pin"
-msgstr ""
+msgstr "Připnout"
 
 #: main/src/windows/conversation_details.vala:104
 msgid "Blocked"
-msgstr ""
+msgstr "Zablokováno"
 
 #: main/src/windows/conversation_details.vala:108
 msgid "Domain blocked"
-msgstr ""
+msgstr "Doména zablokována"
 
 #: main/src/windows/conversation_details.vala:112
 msgid "Block"
@@ -236,29 +236,29 @@ msgstr "Zablokovat"
 #: main/src/windows/conversation_details.vala:131
 #: main/src/windows/conversation_details.vala:132
 msgid "Mute"
-msgstr ""
+msgstr "Ztlumit"
 
 #: main/src/windows/conversation_details.vala:133
 msgid "Notifications enabled"
-msgstr ""
+msgstr "Notifikace zapnuty"
 
 #: main/src/windows/conversation_details.vala:136
 msgid "Notifications for mentions"
-msgstr ""
+msgstr "Notifikace při zmínění"
 
 #: main/src/windows/conversation_details.vala:139
 #: main/src/windows/conversation_details.vala:140
 msgid "Muted"
-msgstr ""
+msgstr "Ztlumeno"
 
 #: main/src/windows/conversation_details.vala:141
 msgid "Notifications disabled"
-msgstr ""
+msgstr "Notifikace vypnuty"
 
 #: main/src/windows/conversation_details.vala:196
 #: main/data/conversation_details.ui:156
 msgid "About"
-msgstr ""
+msgstr "Informace"
 
 #: main/src/windows/conversation_details.vala:199
 msgid "Settings"
@@ -271,7 +271,7 @@ msgstr "Nastavení místnosti"
 #: main/src/windows/conversation_details.vala:238
 #: main/data/preferences_window/preferences_dialog.ui:18
 msgid "Encryption"
-msgstr ""
+msgstr "Šifrování"
 
 #: main/src/windows/conversation_details.vala:248
 #: main/src/ui/conversation_titlebar/occupants_entry.vala:14
@@ -579,11 +579,11 @@ msgstr "Hledat zprávy"
 
 #: main/src/ui/conversation_titlebar/menu_entry.vala:20
 msgid "Conversation Details"
-msgstr ""
+msgstr "Detaily konverzace"
 
 #: main/src/ui/conversation_titlebar/menu_entry.vala:21
 msgid "Close Conversation"
-msgstr ""
+msgstr "Zavřít konverzaci"
 
 #: main/src/ui/call_window/participant_widget.vala:115
 msgid "Debug information"
@@ -860,16 +860,16 @@ msgstr "Správa účtů"
 #: main/src/ui/conversation_details.vala:143
 #: main/data/preferences_window/account_preferences_subpage.ui:68
 msgid "XMPP Address"
-msgstr ""
+msgstr "XMPP adresa"
 
 #: main/src/ui/conversation_details.vala:148
 msgid "Display name"
-msgstr ""
+msgstr "Zobrazované jméno"
 
 #: main/src/ui/conversation_details.vala:168
 #: main/src/ui/conversation_details.vala:182
 msgid "Topic"
-msgstr ""
+msgstr "Popis"
 
 #: main/src/ui/conversation_content_view/message_widget.vala:233
 msgid "Edit message"
@@ -1002,11 +1002,11 @@ msgstr "Přečteno"
 
 #: main/src/ui/conversation_content_view/subscription_notification.vala:49
 msgid "Send request"
-msgstr ""
+msgstr "Poslat žádost"
 
 #: main/src/ui/conversation_content_view/subscription_notification.vala:60
 msgid "You do not receive status updates from this contact yet."
-msgstr ""
+msgstr "Od tohoto kontaktu zatím nedostáváte informace o aktivitě."
 
 #: main/src/ui/conversation_content_view/subscription_notification.vala:80
 msgid "This contact would like to add you to their contact list"
@@ -1027,7 +1027,7 @@ msgstr "Tato konverzace neumožňuje odpovědi."
 #: main/src/ui/conversation_content_view/file_default_widget.vala:75
 #, c-format
 msgid "Downloading %s… (%u%%)"
-msgstr ""
+msgstr "Stahování %s... (%u%%)"
 
 #: main/src/ui/conversation_content_view/file_default_widget.vala:77
 #, c-format
@@ -1037,7 +1037,7 @@ msgstr "Stahování %s…"
 #: main/src/ui/conversation_content_view/file_default_widget.vala:81
 #, c-format
 msgid "Uploading %s… (%u%%)"
-msgstr ""
+msgstr "Nahrávání %s... (%u%%)"
 
 #: main/src/ui/conversation_content_view/file_default_widget.vala:95
 #, c-format
@@ -1063,7 +1063,7 @@ msgstr "Soubor"
 
 #: main/src/ui/conversation_content_view/unread_indicator_populator.vala:76
 msgid "New"
-msgstr ""
+msgstr "Nové"
 
 #: main/data/menu_conversation.ui:7
 msgid "Contact Details"
@@ -1075,7 +1075,7 @@ msgstr "Aktualizovat zprávu"
 
 #: main/data/preferences_window/add_account_dialog.ui:92
 msgid "Login"
-msgstr ""
+msgstr "Přihlásit"
 
 #: main/data/preferences_window/add_account_dialog.ui:147
 msgid "Could not establish a secure connection"
@@ -1107,15 +1107,15 @@ msgstr "Dokončit"
 
 #: main/data/preferences_window/general_preferences_page.ui:9
 msgid "Send _Typing Notifications"
-msgstr ""
+msgstr "Posílat _indikace, že píšete"
 
 #: main/data/preferences_window/general_preferences_page.ui:15
 msgid "Send _Read Receipts"
-msgstr ""
+msgstr "Posílat _potvrzení o přečtení"
 
 #: main/data/preferences_window/general_preferences_page.ui:25
 msgid "_Notifications"
-msgstr ""
+msgstr "_Notifikace"
 
 #: main/data/preferences_window/general_preferences_page.ui:26
 msgid "Notify when a new message arrives"
@@ -1123,7 +1123,7 @@ msgstr "Upozornit, jakmile přijde nová zpráva"
 
 #: main/data/preferences_window/general_preferences_page.ui:36
 msgid "_Convert Smileys to Emoji"
-msgstr ""
+msgstr "_Převádět smajlíky na emoji"
 
 #: main/data/preferences_window/account_preferences_subpage.ui:77
 msgid "Local alias"
@@ -1131,31 +1131,31 @@ msgstr "Místní alias"
 
 #: main/data/preferences_window/account_preferences_subpage.ui:104
 msgid "Connection status"
-msgstr ""
+msgstr "Stav připojení"
 
 #: main/data/preferences_window/account_preferences_subpage.ui:134
 msgid "Remove account"
-msgstr ""
+msgstr "Odebrat účet"
 
 #: main/data/preferences_window/change_password_dialog.ui:5
 msgid "Change password"
-msgstr ""
+msgstr "Změnit heslo"
 
 #: main/data/preferences_window/change_password_dialog.ui:34
 msgid "Change"
-msgstr ""
+msgstr "Změnit"
 
 #: main/data/preferences_window/change_password_dialog.ui:61
 msgid "Current password"
-msgstr ""
+msgstr "Současné heslo"
 
 #: main/data/preferences_window/change_password_dialog.ui:66
 msgid "New password"
-msgstr ""
+msgstr "Nové heslo"
 
 #: main/data/preferences_window/change_password_dialog.ui:71
 msgid "Confirm password"
-msgstr ""
+msgstr "Potvrďte heslo"
 
 #: main/data/preferences_window/preferences_dialog.ui:25
 #: main/data/gtk/help-overlay.ui:10
@@ -1164,11 +1164,11 @@ msgstr "Obecné"
 
 #: main/data/gtk/help-overlay.ui:26
 msgid "Show preferences"
-msgstr ""
+msgstr "Zobrazit předvolby"
 
 #: main/data/gtk/help-overlay.ui:32
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Klávesové zkratky"
 
 #: main/data/gtk/help-overlay.ui:39
 msgid "Conversation"
@@ -1176,7 +1176,7 @@ msgstr "Konverzace"
 
 #: main/data/gtk/help-overlay.ui:55
 msgid "Close conversation"
-msgstr ""
+msgstr "Zavřít konverzaci"
 
 #: main/data/gtk/help-overlay.ui:62
 msgid "Navigation"
@@ -1272,7 +1272,7 @@ msgstr "Odeslat"
 
 #: main/data/menu_app.ui:7
 msgid "Preferences"
-msgstr ""
+msgstr "Předvolby"
 
 #: main/data/menu_app.ui:11
 msgid "Keyboard Shortcuts"


### PR DESCRIPTION
Most of these should be accurate but for a few (such as "About" or
"Topic") a more relaxed translation was used to better fit the
context(s) or feel more natural. The "Send Typing Notifications"
translation is admittedly a bit convoluted.

I was not sure about the meaning of the underscore in for instance "\_Notifications" but I saw that the other languages keep it so I also kept it, although perhaps arbitrarily placed.

Also, it seems that it is not possible to translate the OMEMO section of Preferences.
