### PR TITLE
Fix macOS plugins not loading by building them with .so extension

### DIFF
--- a/plugins/http-files/meson.build
+++ b/plugins/http-files/meson.build
@@ -17,6 +17,6 @@ sources = files(
 vala_args = [
     '-D', 'SOUP_3_0',
 ]
-lib_http_files = shared_library('http-files', sources, name_prefix: '', vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
+lib_http_files = shared_library('http-files', sources, name_prefix: '', name_suffix: 'so', vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
 dep_http_files = declare_dependency(link_with: lib_http_files, include_directories: include_directories('.'))
 summary('HTTP file upload (http-files)', dep_http_files.found(), bool_yn: true, section: 'Plugins')

--- a/plugins/ice/meson.build
+++ b/plugins/ice/meson.build
@@ -24,6 +24,6 @@ c_args = [
 vala_args = [
     '--vapidir', meson.current_source_dir() / 'vapi',
 ]
-lib_ice = shared_library('ice', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
+lib_ice = shared_library('ice', sources, name_prefix: '', name_suffix: 'so', c_args: c_args, vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
 dep_ice = declare_dependency(link_with: lib_ice, include_directories: include_directories('.'))
 summary('Peer-to-peer communication (ice)', dep_ice.found(), bool_yn: true, section: 'Plugins')

--- a/plugins/notification-sound/meson.build
+++ b/plugins/notification-sound/meson.build
@@ -14,6 +14,6 @@ sources = files(
 vala_args = [
     '--vapidir', meson.current_source_dir() / 'vapi',
 ]
-lib_notification_sound = shared_library('notification-sound', sources, name_prefix: '', vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
+lib_notification_sound = shared_library('notification-sound', sources, name_prefix: '', name_suffix: 'so', vala_args: vala_args, dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
 dep_notification_sound = declare_dependency(link_with: lib_notification_sound, include_directories: include_directories('.'))
 summary('Sound for chat notifications (notification-sound)', dep_notification_sound, section: 'Plugins')

--- a/plugins/omemo/meson.build
+++ b/plugins/omemo/meson.build
@@ -69,7 +69,7 @@ vala_args = [
     '--internal-vapi', meson.current_build_dir() / 'omemo-internal.vapi',
     '--internal-header', meson.current_build_dir() / 'omemo-internal.h',
 ]
-lib_omemo = shared_library('omemo', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
+lib_omemo = shared_library('omemo', sources, name_prefix: '', name_suffix: 'so', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
 dep_omemo = declare_dependency(link_with: lib_omemo, include_directories: include_directories('.'))
 summary('End-to-end encryption using OMEMO (omemo)', dep_omemo.found(), bool_yn: true, section: 'Plugins')
 # This is to use the internal vapi instead of the regular

--- a/plugins/openpgp/meson.build
+++ b/plugins/openpgp/meson.build
@@ -43,6 +43,6 @@ vala_args = [
 if dep_libadwaita.version() == 'unknown' or dep_libadwaita.version().version_compare('>=1.4')
     vala_args += ['-D', 'Adw_1_4']
 endif
-lib_openpgp = shared_library('openpgp', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
+lib_openpgp = shared_library('openpgp', sources, name_prefix: '', name_suffix: 'so', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
 dep_openpgp = declare_dependency(link_with: lib_openpgp, include_directories: include_directories('.'))
 summary('End-to-end encryption using PGP (openpgp)', dep_openpgp.found(), bool_yn: true, section: 'Plugins')

--- a/plugins/rtp/meson.build
+++ b/plugins/rtp/meson.build
@@ -79,7 +79,7 @@ if get_option('plugin-rtp-vp9').allowed()
     vala_args += ['-D', 'ENABLE_VP9']
 endif
 
-lib_rtp = shared_library('rtp', sources, name_prefix: '', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
+lib_rtp = shared_library('rtp', sources, name_prefix: '', name_suffix: 'so', c_args: c_args, vala_args: vala_args, include_directories: include_directories('src'), dependencies: dependencies, install: true, install_dir: get_option('libdir') / get_option('plugindir'), install_rpath: default_install_rpath)
 dep_rtp = declare_dependency(link_with: lib_rtp, include_directories: include_directories('.'))
 summary('Voice/video calls (rtp)', dep_rtp.found(), bool_yn: true, section: 'Plugins')
 


### PR DESCRIPTION
Fixes #1782, Dino's plugin loader can't find any plugins on MacOS.

It turns out Meson builds them with with `.dylib` file extension, where GLib's `Module.SUFFIX` wants `.so` (even on Mac).

https://github.com/dino/dino/blob/6c397f39b8fad1cb903331d1ce444eb0569797ba/libdino/src/plugin/loader.vala#L41

To get around these upstream issues, we can tell Meson to build our plugins as `.so` to match GLib's expectations.