### PR TITLE
FreeDesktopNotifier: Activate app before conversation

### DIFF
--- a/main/src/ui/notifier_freedesktop.vala
+++ b/main/src/ui/notifier_freedesktop.vala
@@ -101,6 +101,7 @@ public class Dino.Ui.FreeDesktopNotifier : NotificationProvider, Object {
             content_notifications[conversation] = notification_id;
 
             add_action_listener(notification_id, "default", () => {
+                GLib.Application.get_default().activate();
                 GLib.Application.get_default().activate_action("open-conversation", new Variant.int32(conversation.id));
             });
         } catch (Error e) {


### PR DESCRIPTION
In order to fix crashes when dino is launched in the background with `--gapplication-service` and gets activated via a message notification before the main window has been opened before. That is because MainWindow is contructed in the app activate callback.

Closes https://github.com/dino/dino/issues/833

---

Preparation for https://github.com/dino/dino/pull/1826, but useful for everyone already using manual autostart launchers with `--gapplication-service`