### PR TITLE
muc: only do disco on succesfully entering a room

### DIFF
--- a/xmpp-vala/src/module/xep/0045_muc/module.vala
+++ b/xmpp-vala/src/module/xep/0045_muc/module.vala
@@ -113,7 +113,6 @@ public class Module : XmppStreamModule {
 
             stream.get_flag(Flag.IDENTITY).start_muc_enter(bare_jid, presence.id);
 
-            query_room_info.begin(stream, bare_jid);
             stream.get_module(Presence.Module.IDENTITY).send_presence(stream, presence);
 
             var promise = new Promise<JoinResult?>();
@@ -358,6 +357,8 @@ public class Module : XmppStreamModule {
                 if (status_codes.contains(StatusCode.SELF_PRESENCE)) {
                     Jid bare_jid = presence.from.bare_jid;
                     if (flag.get_enter_id(bare_jid) != null) {
+
+                        query_room_info.begin(stream, bare_jid);
 
                         // TODO only query that if we actually have the rights to
                         query_affiliation.begin(stream, bare_jid, "member");


### PR DESCRIPTION
Sending a disco#info <iq> on being banned from a room is wasteful, and when _creating_ a room dino asks too soon, receives an error, and gives up on syncing the room metadata giving subtle, hair-tearing inconsistencies because flag.has_room_features() returns false for everything.

It's barely noticeable, because if you're banned from a room you can't query it anyway (though in that case it's still a wasted <iq>), and if you're creating the room all its fields are empty by default.

I noticed this because I'm experimenting with https://modules.prosody.im/mod_muc_defaults; dino incorrectly shows moderation off when it should be on in newly created rooms.