### PR TITLE
Expose unread messages count and urgency through LauncherEntry API

### DIFF
--- a/main/meson.build
+++ b/main/meson.build
@@ -71,6 +71,7 @@ sources = files(
     'src/ui/main_window_controller.vala',
     'src/ui/notifier_freedesktop.vala',
     'src/ui/notifier_gnotifications.vala',
+    'src/ui/launcher_entry.vala',
     'src/ui/occupant_menu/list.vala',
     'src/ui/occupant_menu/list_row.vala',
     'src/ui/occupant_menu/view.vala',

--- a/main/src/ui/application.vala
+++ b/main/src/ui/application.vala
@@ -14,6 +14,7 @@ public class Dino.Ui.Application : Adw.Application, Dino.Application {
 
     public MainWindow window;
     public MainWindowController controller;
+    private LauncherEntry launcher_entry;
 
     public Database db { get; set; }
     public Dino.Entities.Settings settings { get; set; }
@@ -55,15 +56,11 @@ public class Dino.Ui.Application : Adw.Application, Dino.Application {
                 }
             });
 
+            launcher_entry = new LauncherEntry(stream_interactor);
+
             notification_events.notify_content_item.connect((content_item, conversation) => {
                 // Set urgency hint also if (normal) notifications are disabled
-                // Don't set urgency hint in GNOME, produces "Window is active" notification
-                var desktop_env = Environment.get_variable("XDG_CURRENT_DESKTOP");
-                if (desktop_env == null || !desktop_env.down().contains("gnome")) {
-                    if (this.active_window != null) {
-//                        this.active_window.urgency_hint = true;
-                    }
-                }
+                launcher_entry.urgency_hint = true;
             });
             stream_interactor.get_module(FileManager.IDENTITY).add_metadata_provider(new Util.AudioVideoFileMetadataProvider());
         });
@@ -75,6 +72,7 @@ public class Dino.Ui.Application : Adw.Application, Dino.Application {
                 window = new MainWindow(this, stream_interactor, db, config);
                 controller.set_window(window);
                 if ((get_flags() & ApplicationFlags.IS_SERVICE) == ApplicationFlags.IS_SERVICE) window.hide_on_close = true;
+                window.notify["is-active"].connect(() => launcher_entry.urgency_hint = false);
             }
             window.present();
         });

--- a/main/src/ui/launcher_entry.vala
+++ b/main/src/ui/launcher_entry.vala
@@ -1,0 +1,94 @@
+using Dino.Entities;
+
+namespace Dino {
+
+[DBus (name = "com.canonical.Unity.LauncherEntry")]
+public interface DBusLauncherEntry : Object {
+    public signal void update(string app_uri, HashTable<string, Variant> properties);
+}
+
+public class Ui.LauncherEntry : DBusLauncherEntry, Object {
+
+    private const string OBJECT_PATH  = "/im/dino/Dino";
+    private const string LAUNCHER_URI = "application://im.dino.Dino.desktop";
+
+    private int64 last_count = -1;
+    private uint update_pending = 0;
+
+    private ChatInteraction chat_interaction;
+    private ConversationManager conversation_manager;
+
+    public LauncherEntry(StreamInteractor stream_interactor) {
+        DBusConnection? conn = GLib.Application.get_default().get_dbus_connection();
+        if (conn == null) return;
+
+        try {
+            conn.register_object(OBJECT_PATH, (DBusLauncherEntry) this);
+        } catch (IOError e) {
+            warning("LauncherEntry: could not register D-Bus object: %s", e.message);
+            return;
+        }
+
+        conversation_manager = stream_interactor.get_module(ConversationManager.IDENTITY);
+        chat_interaction = stream_interactor.get_module(ChatInteraction.IDENTITY);
+
+        foreach (Conversation conversation in conversation_manager.get_active_conversations()) {
+            conversation.notify["read-up-to-item"].connect(schedule_count_update);
+        }
+
+        conversation_manager.conversation_activated.connect((conversation) => {
+            conversation.notify["read-up-to-item"].connect(schedule_count_update);
+            schedule_count_update();
+        });
+
+        conversation_manager.conversation_deactivated.connect((conversation) => {
+            conversation.notify["read-up-to-item"].disconnect(schedule_count_update);
+            schedule_count_update();
+        });
+
+        stream_interactor.get_module(ContentItemStore.IDENTITY).new_item.connect(schedule_count_update);
+
+        schedule_count_update();
+    }
+
+    private void schedule_count_update() {
+        if (update_pending != 0) return;
+
+        update_pending = Idle.add_once(() => {
+            update_pending = 0;
+            do_count_update();
+        });
+    }
+
+    private void do_count_update() {
+        int64 total = 0;
+
+        foreach (Conversation conversation in conversation_manager.get_active_conversations()) {
+            total += chat_interaction.get_num_unread(conversation);
+        }
+
+        if (total == last_count) return;
+        if (total == 0) this.urgency_hint = false;
+        this.count = last_count = total;
+    }
+
+    public int64 count {
+        set {
+            HashTable<string, Variant> props = new HashTable<string, Variant>(null, null);
+            props["count"] = new Variant.int64(value);
+            props["count-visible"] = new Variant.boolean(value > 0);
+            update(LAUNCHER_URI, props);
+        }
+    }
+
+    public bool urgency_hint {
+        set {
+            HashTable<string, Variant> props = new HashTable<string, Variant>(null, null);
+            props["urgent"] = new Variant.boolean(value);
+            update(LAUNCHER_URI, props);
+        }
+    }
+
+}
+
+}


### PR DESCRIPTION
Some desktop enviroments allow applications to expose a counter bubble on their launcher icon using the LauncherEntry API that originated from Unity. Use that to expose unread messages counter and to reimplement the urgency hint that was commented out when porting Dino to GTK4, as GTK4 does not expose such API anymore.

-------------

I was wondering why I started to sometimes miss the fact that I've received new messages in Dino at some point in the last few years, which was something that I never registered happening with Dino for the years before. Recently I've finally started looking into this and found out that Dino has stopped marking its window with urgency hint with the switch to GTK4, as GTK4 does not expose such API anymore, so once the notification has expired it wasn't obvious at all that there were new messages waiting until I actually looked into Dino's window. The urgency hint is however still well supported in some environments, such as Plasma, by using the LauncherEntry D-Bus API, which also allows to display a count badge, used here to show the number of unread messages. This should be enough to always notice incoming messages in the future :)

In the future this could be generalized and made to also support similar APIs on other platforms, as I believe it's a fairly common feature.