### PR TITLE
Add virtual 'Note to Self' roster item

### DIFF
--- a/main/src/ui/add_conversation/roster_list.vala
+++ b/main/src/ui/add_conversation/roster_list.vala
@@ -56,8 +56,22 @@ protected class RosterList {
 
     private void fetch_roster_items(Account account) {
         rows[account] = new HashMap<Jid, ListBoxRow>(Jid.hash_func, Jid.equals_func);
+        bool has_self = false;
         foreach (Roster.Item roster_item in stream_interactor.get_module(RosterManager.IDENTITY).get_roster(account)) {
+            if (roster_item.jid == account.bare_jid) { has_self = true; }
             update_row(account, roster_item.jid);
+        }
+
+        if (!has_self) {
+            // Inject a virtual "Note to Self" contact.
+            // XMPP technically allows people to be on their own contact lists but
+            // in practice it's rarely allowed, in fact there's an embarrassed mention of this in:
+            // https://www.rfc-editor.org/rfc/rfc6121.html#section-2.3.3:
+            // >  Interoperability Note: Some servers return a <not-allowed/> stanza
+            // > error to the client if the value of the <item/> element's 'jid'
+            // > attribute matches the bare JID <localpart@domainpart> of the
+            // > user's account.
+            update_row(account, account.bare_jid);
         }
     }
 

--- a/main/src/ui/conversation_selector/conversation_selector_row.vala
+++ b/main/src/ui/conversation_selector/conversation_selector_row.vala
@@ -39,8 +39,15 @@ public class ConversationSelectorRow : ListBoxRow {
         this.conversation = conversation;
         this.stream_interactor = stream_interactor;
 
-        var display_name_model = stream_interactor.get_module(ContactModels.IDENTITY).get_display_name_model(conversation);
-        display_name_model.bind_property("display-name", name_label, "label", BindingFlags.SYNC_CREATE);
+        if (conversation.type_ == Conversation.Type.CHAT && conversation.counterpart.equals_bare(conversation.account.bare_jid)) {
+            // Support the virtual "Note to Self" contact added by RosterList.fetch_roster_items().
+            // libdino (in the form of ContactModels) cannot know about this contact without also
+            // learning how to localize "Note to Self" using gettext.
+            update_name_label();
+        } else {
+            var display_name_model = stream_interactor.get_module(ContactModels.IDENTITY).get_display_name_model(conversation);
+            display_name_model.bind_property("display-name", name_label, "label", BindingFlags.SYNC_CREATE);
+        }
 
         if (conversation.type_ == Conversation.Type.GROUPCHAT) {
             stream_interactor.get_module(MucManager.IDENTITY).room_info_updated.connect((account, jid) => {
@@ -89,7 +96,6 @@ public class ConversationSelectorRow : ListBoxRow {
         conversation.notify["read-up-to-item"].connect(() => update_read());
         conversation.notify["pinned"].connect(() => { update_pinned_icon(); });
 
-        update_name_label();
         update_pinned_icon();
         content_item_received();
     }

--- a/main/src/ui/conversation_view_controller.vala
+++ b/main/src/ui/conversation_view_controller.vala
@@ -124,8 +124,16 @@ public class ConversationViewController : Object {
         chat_input_controller.set_conversation(conversation);
 
         if (display_name_binding != null) display_name_binding.unbind();
-        var display_name_model = stream_interactor.get_module(ContactModels.IDENTITY).get_display_name_model(conversation);
-        display_name_binding = display_name_model.bind_property("display-name", main_window.conversation_window_title, "title", BindingFlags.SYNC_CREATE);
+        if (conversation.type_ == Conversation.Type.CHAT && conversation.counterpart.equals_bare(conversation.account.bare_jid)) {
+            // Support the virtual "Note to Self" contact added by RosterList.fetch_roster_items().
+            // libdino (in the form of ContactModels) cannot know about this contact without also
+            // learning how to localize "Note to Self" using gettext.
+            display_name_binding = null;
+            main_window.conversation_window_title.title = Util.get_conversation_display_name(stream_interactor, conversation);
+        } else {
+            var display_name_model = stream_interactor.get_module(ContactModels.IDENTITY).get_display_name_model(conversation);
+            display_name_binding = display_name_model.bind_property("display-name", main_window.conversation_window_title, "title", BindingFlags.SYNC_CREATE);
+        }
 
         update_conversation_topic();
 

--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -62,6 +62,12 @@ public static string color_for_show(string show) {
 }
 
 public static string get_conversation_display_name(StreamInteractor stream_interactor, Conversation conversation) {
+    if (conversation.type_ == Conversation.Type.CHAT &&
+            conversation.counterpart.equals_bare(conversation.account.bare_jid)) {
+        // Support the virtual "Note to Self" contact added by RosterList.fetch_roster_items().
+        // libdino cannot do this without also importing gettext.
+        return _("Note to Self");
+    }
     return Dino.get_conversation_display_name(stream_interactor, conversation, _("%s from %s"));
 }
 


### PR DESCRIPTION
Cheogram, Gajim, Signal and WhatsApp all support this, and it is useful.

<img width="515" height="382" alt="Screenshot From 2026-03-07 20-01-45" src="https://github.com/user-attachments/assets/ac5885a7-e792-4e74-8148-7e04513ecc74" />

<img width="511" height="338" alt="image" src="https://github.com/user-attachments/assets/320170c7-008c-459f-8a9e-47de66280f2a" />

I have not updated the translations, I hope that's okay. My understanding is that everything translation, including updating main/po/dino.pot, is handled by Weblate and happens only a few times a year.


## Testing

If you've never built dino before and you want to give this a spin, install the [dependencies](https://github.com/dino/dino/wiki/Build#dependencies) on your system. For Debian that means [these](https://salsa.debian.org/xmpp-team/dino-im/-/blob/debian/master/debian/control?ref_type=heads#L7), Arch are [these](https://gitlab.archlinux.org/archlinux/packaging/packages/dino/-/blob/main/PKGBUILD?ref_type=heads#L11), Fedora is [here](https://src.fedoraproject.org/rpms/dino/blob/rawhide/f/dino.spec#_23).

```
git clone --depth 50 -b note-to-self https://github.com/kousu/dino
cd dino
meson setup build
meson compile -C build
./build/main/dino
```

Let me know if you like it :)