### PR TITLE
Scroll to activated conversations.

### DIFF
--- a/main/data/conversation_selector.ui
+++ b/main/data/conversation_selector.ui
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+    <template class="DinoUiConversationSelector" parent="GtkWidget">
+        <child>
+            <object class="GtkScrolledWindow" id="scrolled">
+                <property name="hscrollbar_policy">never</property>
+                <property name="vexpand">1</property>
+                <child>
+                    <object class="GtkListBox" id="list_box">
+                        <property name="hexpand">1</property>
+                        <style>
+                            <class name="navigation-sidebar"/>
+                        </style>
+                    </object>
+                </child>
+            </object>
+        </child>
+    </template>
+</interface>

--- a/main/data/gresource.xml
+++ b/main/data/gresource.xml
@@ -15,6 +15,7 @@
     <file>conversation_details.ui</file>
     <file>conversation_item_widget.ui</file>
     <file>conversation_row.ui</file>
+    <file>conversation_selector.ui</file>
     <file>conversation_view.ui</file>
     <file>dino-conversation-list-placeholder-arrow.svg</file>
     <file>file_default_widget.ui</file>

--- a/main/data/main_window.ui
+++ b/main/data/main_window.ui
@@ -61,13 +61,7 @@
                                                             <object class="GtkStackPage">
                                                                 <property name="name">content</property>
                                                                 <property name="child">
-                                                                    <object class="GtkScrolledWindow">
-                                                                        <property name="hscrollbar_policy">never</property>
-                                                                        <property name="vexpand">1</property>
-                                                                        <child>
-                                                                            <object class="DinoUiConversationSelector" id="conversation_selector">
-                                                                            </object>
-                                                                        </child>
+                                                                    <object class="DinoUiConversationSelector" id="conversation_selector">
                                                                     </object>
                                                                 </property>
                                                             </object>

--- a/main/src/ui/conversation_selector/conversation_selector.vala
+++ b/main/src/ui/conversation_selector/conversation_selector.vala
@@ -7,21 +7,19 @@ using Dino.Entities;
 
 namespace Dino.Ui {
 
+[GtkTemplate (ui = "/im/dino/Dino/conversation_selector.ui")]
 public class ConversationSelector : Widget {
 
     public signal void conversation_selected(Conversation conversation);
 
-    ListBox list_box = new ListBox() { hexpand=true };
+    [GtkChild] private unowned ScrolledWindow scrolled;
+    [GtkChild] private unowned ListBox list_box;
 
     private StreamInteractor stream_interactor;
     private HashMap<Conversation, ConversationSelectorRow> rows = new HashMap<Conversation, ConversationSelectorRow>(Conversation.hash_func, Conversation.equals_func);
 
     public ConversationSelector init(StreamInteractor stream_interactor) {
         this.stream_interactor = stream_interactor;
-        list_box.set_parent(this);
-        list_box.add_css_class("navigation-sidebar");
-        this.layout_manager = new BinLayout();
-
         stream_interactor.get_module(ConversationManager.IDENTITY).conversation_activated.connect(add_conversation);
         stream_interactor.get_module(ConversationManager.IDENTITY).conversation_deactivated.connect(remove_conversation);
         stream_interactor.get_module(ContentItemStore.IDENTITY).new_item.connect(on_content_item_received);
@@ -37,6 +35,7 @@ public class ConversationSelector : Widget {
     }
 
     construct {
+        this.layout_manager = new BinLayout();
         list_box.set_sort_func(sort);
 
         realize.connect(() => {
@@ -62,21 +61,28 @@ public class ConversationSelector : Widget {
             add_conversation(conversation);
         }
         list_box.select_row(rows[conversation]);
-#if GTK_4_12
-        scroll_to_row(rows[conversation]);
-#endif
+        ConversationSelectorRow row = rows[conversation];
+        Idle.add(() => { scroll_to_row(row); return false; });
     }
 
-#if GTK_4_12
     private void scroll_to_row(ConversationSelectorRow row) {
-        Gtk.Widget? ancestor = this;
-        while (ancestor != null && !(ancestor is Gtk.Viewport)) {
-            ancestor = ancestor.get_parent();
-        }
-        if (ancestor == null) return;
-        ((Gtk.Viewport) ancestor).scroll_to(row, null);
+        double row_x, row_y;
+        if (!row.translate_coordinates(list_box, 0, 0, out row_x, out row_y)) return;
+
+        double row_bottom = row_y + row.get_allocated_height();
+        double vadj_bottom = scrolled.vadjustment.value + scrolled.vadjustment.page_size;
+
+        // don't scroll if any part of the row is visible
+        if (row_bottom > scrolled.vadjustment.value && row_y < vadj_bottom) return;
+
+        // scroll to vertically center the row, if possible
+        double target = row_y + row.get_allocated_height() / 2.0 - scrolled.vadjustment.page_size / 2.0;
+        target = target.clamp(0, scrolled.vadjustment.upper - scrolled.vadjustment.page_size);
+
+        new Adw.TimedAnimation(scrolled, scrolled.vadjustment.value, target, 900,
+            new Adw.PropertyAnimationTarget(scrolled.vadjustment, "value")
+        ).play();
     }
-#endif
 
 
     private void on_content_item_received(ContentItem item, Conversation conversation) {


### PR DESCRIPTION
Long-buried conversations with no recent messages are most easily found by re-"open"ing them with Join Channel or Start Conversation, but when a user does this they stay buried offscreen in the conversation list, even though CSS changes their backgrond colour to indicate they are selected.

Be friendlier by scrolling them into view.


Before (fe2cfd1f24cfbc65362e5094f3aeab0c6279145c) it feels like the opened conversation is a ghost and I'll lose it again if I look away:

https://github.com/user-attachments/assets/8c034d55-b00b-4bd7-a5c9-5d7304c46c4c



After (9d94c60bbde7a5a50589278894866f234a2ec129) it feels grounded in the UI:

https://github.com/user-attachments/assets/0101e0a2-501c-40da-ac39-c72fbf9976bd

