### PR TITLE
Allow updating displayed name for self account.

### DIFF
--- a/libdino/src/service/contact_model.vala
+++ b/libdino/src/service/contact_model.vala
@@ -36,6 +36,11 @@ namespace Dino {
             stream_interactor.get_module(RosterManager.IDENTITY).updated_roster_item.connect((account, jid, roster_item) => {
                 check_update_models(account, jid, Conversation.Type.CHAT);
             });
+            stream_interactor.account_added.connect((account) => {
+                account.notify["alias"].connect(() => {
+                    check_update_models(account, account.bare_jid, Conversation.Type.CHAT);
+                });
+            });
         }
 
         private void check_update_models(Account account, Jid jid, Conversation.Type conversation_ty) {


### PR DESCRIPTION
There is an oversight in these listeners that are supposed to trigger on updates to the output of get_conversation_display_name():

https://github.com/dino/dino/blob/53b52b04530228e58acdfaff882d6b0b471fd098/libdino/src/service/contact_model.vala#L27-L38

They don't track the local alias of the account. It's used in the conversation list and title if someone opens a chat with themselves (which is hard to do without #1840). `Dino.get_conversation_display_name()` loads it here:

https://github.com/dino/dino/blob/fe2cfd1f24cfbc65362e5094f3aeab0c6279145c/libdino/src/util/display_name.vala#L33-L38

This tracks it.

I wonder if `get_conversation_display_name` should just become a `conversation.display_name` property; then, if I understand vala right, all the binds that currently listen to ContactModels could listen directly to converation.display_name and ContactModels would be unnecessary. 

My other PR #1840 hides this issue again by forcing the self-account to be named "Note to Self" so maybe this is pointless. But if anyone besides Dino ever uses libdino they will probably want to be able to listen for _all_ display name changes.