### PR TITLE
Always pre-fill the MUC nick.

### DIFF
--- a/main/src/ui/add_conversation/conference_details_fragment.vala
+++ b/main/src/ui/add_conversation/conference_details_fragment.vala
@@ -19,8 +19,16 @@ protected class ConferenceDetailsFragment : Box {
         set {
             accounts_label.label = value.bare_jid.to_string();
             account_combobox.selected = value;
-            if (nick == null && value.alias != null) {
-                nick = value.alias;
+            if (nick == null) {
+                if(value.alias != null && value.alias != "") {
+                    nick = value.alias;
+                } else if(value.bare_jid.localpart != null && value.bare_jid.localpart != "") {
+                    nick = value.bare_jid.localpart;
+                } else {
+                    // if you have managed to log in _as a XMPP component_
+                    // then use the full domain as the MUC nick
+                    nick = value.bare_jid.to_string();
+                }
             }
             accounts_stack.set_visible_child_name("label");
         }


### PR DESCRIPTION
Fallback to using the account JID's user@ part to make the MUC nick if nothing else specified. This is what Gajim and Conversations do and it reduces the friction when joining new rooms a lot! In fact they don't even allow picking your nick until you've joined the room, except by setting your local account alias first.

Before (fe2cfd1f24cfbc65362e5094f3aeab0c6279145c), joining is slow, I need to retype my name for every room :

https://github.com/user-attachments/assets/c9bcc479-ecd3-4f0c-90e4-558757b47bc9


After (5d9203d3ea2567a0e5e8eb2096a3b6ea02c47579),the Join button is immediately active :

https://github.com/user-attachments/assets/c99d58be-e313-48d8-98c1-11bf603fa81b
