### PR TITLE
Offer to join MUCs on the default server.

### DIFF
--- a/main/src/ui/add_conversation/add_conference_dialog.vala
+++ b/main/src/ui/add_conversation/add_conference_dialog.vala
@@ -86,6 +86,24 @@ public class AddConferenceDialog : Gtk.Dialog {
         conference_list_box.row_activated.connect(() => { ok_button.clicked(); });
 
         select_fragment = new SelectJidFragment(stream_interactor, conference_list_box, stream_interactor.get_accounts());
+        select_fragment.suggest_jids = (str, account) => {
+            var suggestions = new ArrayList<Jid>();
+            // If the user typed a full JID, suggest it directly
+            try {
+                Jid parsed_jid = new Jid(str);
+                if (parsed_jid.localpart != null) suggestions.add(parsed_jid);
+            } catch (InvalidJidError ignored) {}
+            // If the user typed a bare name, suggest it on the default MUC server
+            if (str != "" && !str.contains("@")) {
+                MucManager? muc_manager = stream_interactor.get_module(MucManager.IDENTITY);
+                if (muc_manager != null && muc_manager.default_muc_server.has_key(account)) {
+                    try {
+                        suggestions.add(new Jid(str + "@" + muc_manager.default_muc_server[account].to_string()));
+                    } catch (InvalidJidError ignored) {}
+                }
+            }
+            return suggestions;
+        };
         select_fragment.add_jid.connect((row) => {
             AddGroupchatDialog dialog = new AddGroupchatDialog(stream_interactor);
             dialog.set_transient_for(this);

--- a/main/src/ui/add_conversation/select_contact_dialog.vala
+++ b/main/src/ui/add_conversation/select_contact_dialog.vala
@@ -64,6 +64,17 @@ public class SelectContactDialog : Gtk.Dialog {
         roster_list_box = roster_list.get_list_box();
         roster_list_box.row_activated.connect(() => { ok_button.clicked(); });
         select_jid_fragment = new SelectJidFragment(stream_interactor, roster_list_box, accounts);
+        select_jid_fragment.suggest_jids = (str, account) => {
+            var suggestions = new ArrayList<Jid>();
+            try {
+                Jid parsed_jid = new Jid(str);
+                if (parsed_jid.localpart != null) {
+                    suggestions.add(parsed_jid);
+                    return suggestions;
+                }
+            } catch (InvalidJidError ignored) {}
+            return suggestions;
+        };
         select_jid_fragment.add_jid.connect((row) => {
             AddContactDialog add_contact_dialog = new AddContactDialog(stream_interactor);
             add_contact_dialog.set_transient_for(this);

--- a/main/src/ui/add_conversation/select_jid_fragment.vala
+++ b/main/src/ui/add_conversation/select_jid_fragment.vala
@@ -6,6 +6,8 @@ using Xmpp;
 
 namespace Dino.Ui {
 
+public delegate Gee.List<Jid> SuggestJids(string str, Account account);
+
 [GtkTemplate (ui = "/im/dino/Dino/add_conversation/select_jid_fragment.ui")]
 public class SelectJidFragment : Gtk.Box {
 
@@ -15,6 +17,8 @@ public class SelectJidFragment : Gtk.Box {
         get { return list.get_selected_row() != null; }
         private set {}
     }
+
+    public SuggestJids suggest_jids = null;
 
     [GtkChild] private unowned Entry entry;
     [GtkChild] private unowned Box box;
@@ -60,18 +64,37 @@ public class SelectJidFragment : Gtk.Box {
         filter_values = str == "" ? null : str.split(" ");
         list.invalidate_filter();
 
-        try {
-            Jid parsed_jid = new Jid(str);
-            if (parsed_jid != null && parsed_jid.localpart != null) {
-                foreach (Account account in accounts) {
-                    var list_row = new Gtk.ListBoxRow();
-                    list_row.set_child(new AddListRow(stream_interactor, parsed_jid, account));
-                    list.append(list_row);
-                    added_rows.add(list_row);
-                }
+        // Add suggested JIDs from our owner as synthetic ListBox rows.
+        //
+        // First build a set of existing JIDs to avoid dupes.
+        // XXX this is medium-expensive to do on each keystroke;
+        // can we make add/remove signals on the ListBox to hook?
+        var present = new Gee.HashMap<Account, Gee.HashSet<Jid>>(Account.hash_func, Account.equals_func);
+        for (var child = list.get_first_child(); child != null; child = child.get_next_sibling()) {
+            var row = child as Gtk.ListBoxRow;
+            if (row == null) continue;
+            var list_row = row.get_child() as ListRow;
+            if (list_row == null || list_row.jid == null || list_row.account == null) continue;
+            if (!present.has_key(list_row.account)) {
+                present[list_row.account] = new Gee.HashSet<Jid>(Jid.hash_func, Jid.equals_func);
             }
-        } catch (InvalidJidError ignored) {
-            // Ignore
+            present[list_row.account].add(list_row.jid);
+        }
+
+        // Then actually add them
+        foreach (Account account in accounts) {
+            Gee.List<Jid> suggestions = suggest_jids(str, account);
+            foreach (Jid jid in suggestions) {
+                if (present.has_key(account) && present[account].contains(jid)) continue;
+                if (!present.has_key(account)) {
+                    present[account] = new Gee.HashSet<Jid>(Jid.hash_func, Jid.equals_func);
+                }
+                present[account].add(jid);
+                var list_row = new Gtk.ListBoxRow();
+                list_row.set_child(new AddListRow(stream_interactor, jid, account));
+                list.append(list_row);
+                added_rows.add(list_row);
+            }
         }
     }
 


### PR DESCRIPTION
This allows a user when joining a conference to type *just* the room name then click on e.g. room@conference.example.org from the list. This makes creating new rooms a lot easier.

It also makes joining rooms in a community server (e.g. Snikket) less painful, though without a "Browse Space" button someone still needs to inform each user what the room names are.

I moved the synthetic contact generation code out into callbacks, on the theory that SelectJidFragment shouldn't know specifics of contacts vs MUCs. But maybe that is wrong, feedback welcome.

While adding this, fix a long-standing UX glitch that typing a pre-existing contact into the Start Conversation dialog shows them twice in the list, because now SelectJidFragment filters out all duplicate suggestions.

## Demo

### Before (fe2cfd1f24cfbc65362e5094f3aeab0c6279145c)

Creating a group chat means remembering how to spell my MUC server:

https://github.com/user-attachments/assets/31d735f3-d31d-46c2-bdb0-a6a4369f19ef

and if I type a full contact it's in the list twice:

https://github.com/user-attachments/assets/9777c299-09b2-415b-92db-298132cfacec

### After (228c908cd17bbbcb45a13f0a37ff8f36fb3300ba)

Creating a group is easy:


https://github.com/user-attachments/assets/74072c74-211e-4fae-820a-5e01cf04d9c4


and duplicate contacts are suppressed in Start Conversation:

https://github.com/user-attachments/assets/9827fe36-852c-4002-8cfc-399f81e34b55



