### PR TITLE
Configure newly created rooms.

### DIFF
--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -91,6 +91,17 @@ public class MucManager : StreamInteractionModule, Object {
         mucs_joining[account].remove(jid);
 
         if (res.nick != null) {
+
+            if(res.newly_created) {
+                // https://xmpp.org/extensions/xep-0045.html#createroom
+                // without this, the room does not fully exist and is "locked"
+                // https://xmpp.org/extensions/xep-0045.html#enter-locked
+                // and gives misleading item-not-found errors to other people attempting to join it.
+
+                var form = yield stream.get_module(Xep.Muc.Module.IDENTITY).get_config_form(stream, jid.bare_jid);
+                yield stream.get_module(Xep.Muc.Module.IDENTITY).set_config_form(stream, jid.bare_jid, form);
+            }
+
             // Join completed
             enter_errors.unset(jid);
             if (!already_autojoin) set_autojoin(account, stream, jid, nick, password);

--- a/libdino/src/service/muc_manager.vala
+++ b/libdino/src/service/muc_manager.vala
@@ -97,9 +97,7 @@ public class MucManager : StreamInteractionModule, Object {
                 // without this, the room does not fully exist and is "locked"
                 // https://xmpp.org/extensions/xep-0045.html#enter-locked
                 // and gives misleading item-not-found errors to other people attempting to join it.
-
-                var form = yield stream.get_module(Xep.Muc.Module.IDENTITY).get_config_form(stream, jid.bare_jid);
-                yield stream.get_module(Xep.Muc.Module.IDENTITY).set_config_form(stream, jid.bare_jid, form);
+                yield stream.get_module(Xep.Muc.Module.IDENTITY).configure_instant_room(stream, jid.bare_jid);
             }
 
             // Join completed

--- a/xmpp-vala/src/module/xep/0045_muc/module.vala
+++ b/xmpp-vala/src/module/xep/0045_muc/module.vala
@@ -142,6 +142,12 @@ public class Module : XmppStreamModule {
         }
     }
 
+    public async void configure_instant_room(XmppStream stream, Jid jid) {
+        // "instant" room: https://xmpp.org/extensions/xep-0045.html#createroom-instant
+        var form = new DataForms.DataForm();
+        yield set_config_form(stream, jid, form);
+    }
+
     public void change_subject(XmppStream stream, Jid jid, string subject) {
         MessageStanza message = new MessageStanza();
         message.to = jid;


### PR DESCRIPTION
This is a mandatory part of XEP-0045. Without it, rooms Dino makes are stuck in the ephemeral 'locked' state, neither joinable nor delete-able.

## Demo

### Before (fe2cfd1f24cfbc65362e5094f3aeab0c6279145c)


https://github.com/user-attachments/assets/1457aadb-2287-485c-b8d2-a6562e0fab17


### After (d0b099a06490c6584052263ce50c42966e608974)

https://github.com/user-attachments/assets/52047b21-7fdf-4f49-8938-89d5a14d31b6

