### PR TITLE
Disable JID picker's '-' button on synthetic suggestions.

### DIFF
--- a/main/src/ui/add_conversation/select_jid_fragment.vala
+++ b/main/src/ui/add_conversation/select_jid_fragment.vala
@@ -77,7 +77,7 @@ public class SelectJidFragment : Gtk.Box {
 
     private void check_buttons_active() {
         ListBoxRow? row = list.get_selected_row();
-        bool active = row != null && !row.get_type().is_a(typeof(AddListRow));
+        bool active = row != null && row.child != null && !row.child.get_type().is_a(typeof(AddListRow));
         remove_button.sensitive = active;
     }
 


### PR DESCRIPTION
Actually the JID picker's '-' button was already supposed to be disabled on the artificial entries but at some point it broke, probably in f44cbe02c17df1f02ad49c63cd784fec0ea02d85 when AddListRow became a child during the GTK4 port.

## Demo

### Before (fe2cfd1f24cfbc65362e5094f3aeab0c6279145c)

You can try to remove nonexistent contacts and rooms. It doesn't do anything but it's confusing.

https://github.com/user-attachments/assets/2708e86a-9333-42cb-ae7c-bc9fc89337cb

### After (d43f3640369e44328eb0c23a65a4ceef8622f700)

the - button is disabled on the entries which do not represent anything yet in the database

https://github.com/user-attachments/assets/3a00cd4d-580a-4b31-b109-fe23de0776b9
