### PR TITLE
Add support for preformatted text block styling

### DIFF
--- a/main/src/ui/util/helper.vala
+++ b/main/src/ui/util/helper.vala
@@ -291,6 +291,25 @@ public static string parse_add_markup_theme(string s_, string? highlight_word, b
         already_escaped = true;
     }
 
+    if (parse_text_markup) {
+        Regex preformatted_regex = new Regex("((?<=\n)|^)(```.*\n)([\\s\\S\n]*?)(\n```(?=\n|$)|$)");
+        MatchInfo preformatted_match_info;
+        preformatted_regex.match(s, 0, out preformatted_match_info);
+        if (preformatted_match_info.matches()) {
+            int start_head, end_head,
+                start_body, end_body,
+                start_foot, end_foot;
+            preformatted_match_info.fetch_pos(2, out start_head, out end_head);
+            preformatted_match_info.fetch_pos(3, out start_body, out end_body);
+            preformatted_match_info.fetch_pos(4, out start_foot, out end_foot);
+            return parse_add_markup_theme(s[0:start_head], highlight_word, parse_links, parse_text_markup, parse_quotes, dark_theme, ref theme_dependent, already_escaped) +
+                    "<span color='#9E9E9E'>" + s[start_head:end_head] + "</span>" +
+                    "<tt>" + s[start_body:end_body] + "</tt>" +
+                    "<span color='#9E9E9E'>" + s[start_foot:end_foot] + "</span>" +
+                    parse_add_markup_theme(s[end_foot:s.length], highlight_word, parse_links, parse_text_markup, parse_quotes, dark_theme, ref theme_dependent, already_escaped);
+        }
+    }
+
     if (highlight_word != null) {
         try {
             Regex highlight_regex = new Regex("\\b" + Regex.escape_string(highlight_word.down()) + "\\b", RegexCompileFlags.CASELESS);


### PR DESCRIPTION
Added support for [preformatted text block](https://xmpp.org/extensions/xep-0393.html#pre-block) styling, the last missing piece from a full [XEP-0393](https://xmpp.org/extensions/xep-0393.html#pre-block) implementation.

<img width="481" height="244" alt="Some Python code" src="https://github.com/user-attachments/assets/0590dd01-3219-45bf-9c2c-ef67d7e742cd" />

It even handles ["No closing preformatted text sequence"](https://xmpp.org/extensions/xep-0393.html#example-4) correctly:

<img width="470" height="333" alt="No closing preformatted text sequence" src="https://github.com/user-attachments/assets/32f7df74-398f-4fdb-8563-c8b6c4f9e51f" />

However, it does not handle preformatted text blocks inside quotation blocks correctly, as that'll require me to modify the `parse_quotes` logic, and I figured that's too much code for a single PR.

<img width="342" height="230" alt="preformatted text block inside a quotation block" src="https://github.com/user-attachments/assets/3f12b478-23b0-4bc4-9a49-c449d3d1dc95" />