### PR TITLE
UI: chat_text_view.vala: fix Ctrl+S in editor to make a text strikethrough

### DIFF
--- a/main/data/gtk/help-overlay.ui
+++ b/main/data/gtk/help-overlay.ui
@@ -59,6 +59,29 @@
                 </child>
                 <child>
                     <object class="GtkShortcutsGroup">
+                        <property name="title" translatable="yes">Message editor</property>
+                        <child>
+                            <object class="GtkShortcutsShortcut">
+                                <property name="accelerator">&lt;ctrl&gt;B</property>
+                                <property name="title" translatable="yes">Make the selected text Strong (bold font)</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkShortcutsShortcut">
+                                <property name="accelerator">&lt;ctrl&gt;I</property>
+                                <property name="title" translatable="yes">Make the selected text Emphasized (italic font)</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkShortcutsShortcut">
+                                <property name="accelerator">&lt;ctrl&gt;S</property>
+                                <property name="title" translatable="yes">Make the selected text Deleted (strikethrough font)</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+                <child>
+                    <object class="GtkShortcutsGroup">
                         <property name="title" translatable="yes">Navigation</property>
                         <child>
                             <object class="GtkShortcutsShortcut">

--- a/main/src/ui/chat_input/chat_text_view.vala
+++ b/main/src/ui/chat_input/chat_text_view.vala
@@ -193,11 +193,6 @@ public class ChatTextView : Box {
     }
 
     public Gee.List<Xep.MessageMarkup.Span> get_markups() {
-        var markups = new HashMap<Xep.MessageMarkup.SpanType, Xep.MessageMarkup.SpanType>();
-        markups[Xep.MessageMarkup.SpanType.EMPHASIS] = Xep.MessageMarkup.SpanType.EMPHASIS;
-        markups[Xep.MessageMarkup.SpanType.STRONG_EMPHASIS] = Xep.MessageMarkup.SpanType.STRONG_EMPHASIS;
-        markups[Xep.MessageMarkup.SpanType.DELETED] = Xep.MessageMarkup.SpanType.DELETED;
-
         var ended_groups = new ArrayList<Xep.MessageMarkup.Span>();
         Xep.MessageMarkup.Span current_span = null;
 

--- a/main/src/ui/chat_input/chat_text_view.vala
+++ b/main/src/ui/chat_input/chat_text_view.vala
@@ -162,7 +162,7 @@ public class ChatTextView : Box {
 
         // Style text section bold (CTRL + b) or italic (CTRL + i)
         if ((state & ModifierType.CONTROL_MASK) > 0) {
-            if (keyval in new uint[]{ Key.i, Key.b }) {
+            if (keyval in new uint[]{ Key.i, Key.b, Key.s }) {
                 TextIter start_selection, end_selection;
                 text_view.buffer.get_selection_bounds(out start_selection, out end_selection);
 


### PR DESCRIPTION
As you may see it's checked inside
https://github.com/dino/dino/blob/d33adf1d4d3f127ed3cecbc1faf95fecd3d805a4/main/src/ui/chat_input/chat_text_view.vala#L178

We just forgot to add it to the filter.