### PR TITLE
Fix chat correction content item lookup

### DIFF
--- a/libdino/src/service/database.vala
+++ b/libdino/src/service/database.vala
@@ -7,7 +7,7 @@ using Dino.Entities;
 namespace Dino {
 
 public class Database : Qlite.Database {
-    private const int VERSION = 33;
+    private const int VERSION = 32;
 
     public class AccountTable : Table {
         public Column<int> id = new Column.Integer("id") { primary_key = true, auto_increment = true };
@@ -689,16 +689,6 @@ public class Database : Qlite.Database {
                 exec(@"UPDATE conversation SET active_last_changed=$active_last_updated WHERE active_last_changed=0");
             } catch (Error e) {
                 error("Failed to upgrade to database version 23 (conversation): %s", e.message);
-            }
-        }
-        if (oldVersion < 33) {
-            try {
-                exec("""
-                delete from content_item
-                where content_type=1
-                    and foreign_id not in (select id from message)""");
-            } catch (Error e) {
-                error("Failed to upgrade to database version 33: %s", e.message);
             }
         }
     }

--- a/libdino/src/service/database.vala
+++ b/libdino/src/service/database.vala
@@ -7,7 +7,7 @@ using Dino.Entities;
 namespace Dino {
 
 public class Database : Qlite.Database {
-    private const int VERSION = 32;
+    private const int VERSION = 33;
 
     public class AccountTable : Table {
         public Column<int> id = new Column.Integer("id") { primary_key = true, auto_increment = true };
@@ -689,6 +689,16 @@ public class Database : Qlite.Database {
                 exec(@"UPDATE conversation SET active_last_changed=$active_last_updated WHERE active_last_changed=0");
             } catch (Error e) {
                 error("Failed to upgrade to database version 23 (conversation): %s", e.message);
+            }
+        }
+        if (oldVersion < 33) {
+            try {
+                exec("""
+                delete from content_item
+                where content_type=1
+                    and foreign_id not in (select id from message)""");
+            } catch (Error e) {
+                error("Failed to upgrade to database version 33: %s", e.message);
             }
         }
     }

--- a/libdino/src/service/message_correction.vala
+++ b/libdino/src/service/message_correction.vala
@@ -230,7 +230,7 @@ public class MessageCorrection : StreamInteractionModule, MessageListener {
         if (message.occupant_db_id != -1) {
             qry.outer_join_with(db.message_occupant_id, db.message_occupant_id.message_id, db.message.id)
                 .with(db.message_occupant_id.occupant_id, "=", message.occupant_db_id);
-        } else if (message.counterpart.resourcepart != null) {
+        } else if (message.type_ != Message.Type.CHAT && message.counterpart.resourcepart != null) {
             qry.with(db.message.counterpart_resource, "=", message.counterpart.resourcepart);
         }
         RowOption row = qry.single().row();

--- a/libdino/src/service/message_correction.vala
+++ b/libdino/src/service/message_correction.vala
@@ -195,7 +195,9 @@ public class MessageCorrection : StreamInteractionModule, MessageListener {
                 .perform();
 
         int current_correction_message_id = get_latest_correction_message_id(conversation, original_message);
-        if (content_item != null) {
+        if (current_correction_message_id == -1) warning("Stored correction but got no latest correction %i -> %i", correction_message.id, original_message.id);
+
+        if (content_item != null && current_correction_message_id != -1) {
             db.content_item.update()
                     .with(db.content_item.id, "=", content_item.id)
                     .with(db.content_item.content_type, "=", 1)
@@ -227,12 +229,15 @@ public class MessageCorrection : StreamInteractionModule, MessageListener {
                 .with(db.message_correction.to_stanza_id, "=", message.edit_to ?? message.stanza_id)
                 .order_by(db.message.time, "DESC");
 
-        if (message.occupant_db_id != -1) {
-            qry.outer_join_with(db.message_occupant_id, db.message_occupant_id.message_id, db.message.id)
-                .with(db.message_occupant_id.occupant_id, "=", message.occupant_db_id);
-        } else if (message.type_ != Message.Type.CHAT && message.counterpart.resourcepart != null) {
-            qry.with(db.message.counterpart_resource, "=", message.counterpart.resourcepart);
+        if (message.type_.is_muc_semantic()) {
+            if (message.occupant_db_id != -1) {
+                qry.outer_join_with(db.message_occupant_id, db.message_occupant_id.message_id, db.message.id)
+                    .with(db.message_occupant_id.occupant_id, "=", message.occupant_db_id);
+            } else if (message.counterpart.resourcepart != null) {
+                qry.with(db.message.counterpart_resource, "=", message.counterpart.resourcepart);
+            }
         }
+
         RowOption row = qry.single().row();
         if (row.is_present()) {
             return row[db.message.id];


### PR DESCRIPTION
Direct chat corrections are accepted by bare JID, but the latest correction lookup still constrained the query by the original full resource; a correction sent from another resource therefore produced no matching correction row, returned -1, and wrote that sentinel into the message content item's foreign id.

Align the lookup with the acceptance rule: retain occupant id matching for MUC corrections, retain resource matching for non chat cases where it is still meaningful, and avoid resource filtering for direct chat corrections. Add a database migration which removes existing message content items whose referenced message row no longer exists.