### PR TITLE
Make file downloads recoverable

### DIFF
--- a/libdino/src/entity/file_transfer.vala
+++ b/libdino/src/entity/file_transfer.vala
@@ -260,6 +260,12 @@ public class FileTransfer : Object {
         return File.new_for_path(Path.build_filename(Dino.get_storage_dir(), "files", path));
     }
 
+    public File? get_partial_file() {
+        File? file = get_file();
+        if (file == null) return null;
+        return File.new_for_path(file.get_path() + ".part");
+    }
+
     private void on_update(Object o, ParamSpec sp) {
         Qlite.UpdateBuilder update_builder = db.file_transfer.update().with(db.file_transfer.id, "=", id);
         switch (sp.name) {

--- a/libdino/src/file_transfer/http_transfer.vala
+++ b/libdino/src/file_transfer/http_transfer.vala
@@ -72,6 +72,10 @@ namespace Dino {
             string transfer_host = Uri.parse(receive_data.url, UriFlags.NONE).get_host();
             get_message.accept_certificate.connect((peer_cert, errors) => { return ConnectionManager.on_invalid_certificate(transfer_host, peer_cert, errors); });
             InputStream stream = yield session.send_async(get_message, GLib.Priority.LOW, file_transfer.cancellable);
+            if (get_message.status_code != 200) {
+                try { stream.close(); } catch (Error e) {}
+                throw new IOError.FAILED("HTTP status code %u".printf(get_message.status_code));
+            }
 
             if (file_size != -1) {
                 return new LimitInputStream(stream, file_size);

--- a/libdino/src/service/file_manager.vala
+++ b/libdino/src/service/file_manager.vala
@@ -176,9 +176,19 @@ public class FileManager : StreamInteractionModule, Object {
     }
 
     public async void download_file(FileTransfer file_transfer) {
-        Conversation conversation = stream_interactor.get_module(ConversationManager.IDENTITY).get_conversation(file_transfer.counterpart.bare_jid, file_transfer.account);
+        if (file_transfer.state == FileTransfer.State.COMPLETE || file_transfer.state == FileTransfer.State.IN_PROGRESS) return;
+
+        Conversation? conversation = stream_interactor.get_module(ConversationManager.IDENTITY).get_conversation(file_transfer.counterpart.bare_jid, file_transfer.account);
+        if (conversation == null) {
+            fail_download(file_transfer);
+            return;
+        }
 
         FileProvider? file_provider = this.select_file_provider(file_transfer);
+        if (file_provider == null) {
+            fail_download(file_transfer);
+            return;
+        }
 
         yield download_file_internal(file_provider, file_transfer, conversation);
     }
@@ -217,6 +227,17 @@ public class FileManager : StreamInteractionModule, Object {
         file_decryptors.add(decryptor);
     }
 
+    public int64 get_expected_file_size(FileTransfer file_transfer) {
+        if (file_transfer.encryption == Encryption.NONE) return file_transfer.size;
+
+        foreach (FileDecryptor file_decryptor in file_decryptors) {
+            if (file_decryptor.get_encryption() == file_transfer.encryption) {
+                return file_decryptor.get_expected_file_size(file_transfer, file_transfer.size);
+            }
+        }
+        return -1;
+    }
+
     public void add_metadata_provider(FileMetadataProvider file_metadata_provider) {
         file_metadata_providers.add(file_metadata_provider);
     }
@@ -243,104 +264,164 @@ public class FileManager : StreamInteractionModule, Object {
     }
 
     private async void download_file_internal(FileProvider file_provider, FileTransfer file_transfer, Conversation conversation) {
-        try {
-            // Get meta info
-            FileReceiveData? receive_data = file_provider.get_file_receive_data(file_transfer);
-            if (receive_data == null) {
-                warning("Don't have download data (yet)");
+        file_transfer.cancellable.reset();
+        if (file_transfer.state == FileTransfer.State.FAILED) file_transfer.state = FileTransfer.State.NOT_STARTED;
+        file_transfer.state = FileTransfer.State.IN_PROGRESS;
+
+        Gee.List<FileReceiveData> receive_data_candidates = get_file_receive_data_candidates(file_provider, file_transfer);
+        foreach (FileReceiveData receive_data in receive_data_candidates) {
+            file_transfer.transferred_bytes = 0;
+            try {
+                yield download_file_attempt(file_provider, file_transfer, conversation, receive_data);
+                file_transfer.state = FileTransfer.State.COMPLETE;
                 return;
+            } catch (IOError.CANCELLED e) {
+                cancel_download(file_transfer);
+                return;
+            } catch (Error e) {
+                warning("Error downloading file: %s", e.message);
             }
-            FileDecryptor? file_decryptor = null;
-            foreach (FileDecryptor decryptor in file_decryptors) {
-                if (decryptor.can_decrypt_file(conversation, file_transfer, receive_data)) {
-                    file_decryptor = decryptor;
-                    break;
-                }
+        }
+
+        fail_download(file_transfer);
+    }
+
+    private Gee.List<FileReceiveData> get_file_receive_data_candidates(FileProvider file_provider, FileTransfer file_transfer) {
+        var receive_data_candidates = new ArrayList<FileReceiveData>();
+
+        if (file_transfer.provider == SFS_PROVIDER_ID) {
+            var urls = new HashSet<string>();
+            foreach (var source in file_transfer.sfs_sources) {
+                var http_source = source as Xep.StatelessFileSharing.HttpSource;
+                if (http_source == null || !urls.add(http_source.url)) continue;
+                receive_data_candidates.add(new HttpFileReceiveData() { url=http_source.url });
             }
+        } else {
+            FileReceiveData? receive_data = file_provider.get_file_receive_data(file_transfer);
+            if (receive_data != null) receive_data_candidates.add(receive_data);
+        }
 
-            if (file_decryptor != null) {
-                receive_data = file_decryptor.prepare_get_meta_info(conversation, file_transfer, receive_data);
+        return receive_data_candidates;
+    }
+
+    private async void download_file_attempt(FileProvider file_provider, FileTransfer file_transfer, Conversation conversation, FileReceiveData receive_data_) throws Error {
+        // Get meta info
+        FileReceiveData receive_data = receive_data_;
+        FileDecryptor? file_decryptor = null;
+        foreach (FileDecryptor decryptor in file_decryptors) {
+            if (decryptor.can_decrypt_file(conversation, file_transfer, receive_data)) {
+                file_decryptor = decryptor;
+                break;
             }
+        }
 
-            FileMeta file_meta = yield get_file_meta(file_provider, file_transfer, conversation, receive_data);
+        if (file_decryptor != null) {
+            receive_data = file_decryptor.prepare_get_meta_info(conversation, file_transfer, receive_data);
+        }
 
-            // Download and decrypt file
-            file_transfer.state = FileTransfer.State.IN_PROGRESS;
+        FileMeta file_meta = yield get_file_meta(file_provider, file_transfer, conversation, receive_data);
 
-            if (file_decryptor != null) {
-                file_meta = file_decryptor.prepare_download_file(conversation, file_transfer, receive_data, file_meta);
-            }
+        // Download and decrypt file
+        if (file_decryptor != null) {
+            file_meta = file_decryptor.prepare_download_file(conversation, file_transfer, receive_data, file_meta);
+        }
 
-            InputStream download_input_stream = yield file_provider.download(file_transfer, receive_data, file_meta);
-            InputStream input_stream = download_input_stream;
-            if (file_decryptor != null) {
-                input_stream = yield file_decryptor.decrypt_file(input_stream, conversation, file_transfer, receive_data);
-            }
+        InputStream download_input_stream = yield file_provider.download(file_transfer, receive_data, file_meta);
+        InputStream input_stream = download_input_stream;
+        if (file_decryptor != null) {
+            input_stream = yield file_decryptor.decrypt_file(input_stream, conversation, file_transfer, receive_data);
+        }
 
-            // Update current download progress in the FileTransfer
-            LimitInputStream? limit_stream = download_input_stream as LimitInputStream;
-            if (limit_stream != null) {
-                limit_stream.bind_property("retrieved-bytes", file_transfer, "transferred-bytes", BindingFlags.SYNC_CREATE);
-            }
+        // Update current download progress in the FileTransfer
+        LimitInputStream? limit_stream = download_input_stream as LimitInputStream;
+        if (limit_stream != null) {
+            limit_stream.bind_property("retrieved-bytes", file_transfer, "transferred-bytes", BindingFlags.SYNC_CREATE);
+        }
 
-            // Save file
-            string filename = Random.next_int().to_string("%x") + "_" + file_transfer.file_name;
-            File file = File.new_for_path(Path.build_filename(get_storage_dir(), filename));
+        // Save file
+        string filename = file_transfer.path ?? Random.next_int().to_string("%x") + "_" + file_transfer.file_name;
+        file_transfer.path = filename;
+        File file = File.new_for_path(Path.build_filename(get_storage_dir(), filename));
+        File partial_file = File.new_for_path(file.get_path() + ".part");
 
-            // libsoup doesn't properly support splicing
-            OutputStream os = file.create(FileCreateFlags.REPLACE_DESTINATION);
-            uint8[] buffer = new uint8[1024];
-            ssize_t read;
-            while ((read = yield input_stream.read_async(buffer, Priority.LOW, file_transfer.cancellable)) > 0) {
-                buffer.length = (int) read;
-                yield os.write_async(buffer, Priority.LOW, file_transfer.cancellable);
-                buffer.length = 1024;
-            }
-            yield input_stream.close_async(Priority.LOW, file_transfer.cancellable);
-            yield os.close_async(Priority.LOW, file_transfer.cancellable);
+        // libsoup doesn't properly support splicing
+        OutputStream output_stream = partial_file.create(FileCreateFlags.REPLACE_DESTINATION);
 
-            // Verify the hash of the downloaded file, if it is known
-            var supported_hashes = Xep.CryptographicHashes.get_supported_hashes(file_transfer.hashes);
-            if (!supported_hashes.is_empty) {
-                var checksum_types = new ArrayList<ChecksumType>();
-                var hashes = new HashMap<ChecksumType, string>();
-                foreach (var hash in supported_hashes) {
-                    var checksum_type = Xep.CryptographicHashes.hash_string_to_type(hash.algo);
-                    checksum_types.add(checksum_type);
-                    hashes[checksum_type] = hash.val;
-                }
+        uint8[] buffer = new uint8[1024];
+        ssize_t read;
+        while ((read = yield input_stream.read_async(buffer, Priority.LOW, file_transfer.cancellable)) > 0) {
+            buffer.length = (int) read;
+            yield output_stream.write_all_async(buffer, Priority.LOW, file_transfer.cancellable, null);
+            buffer.length = 1024;
+        }
+        yield input_stream.close_async(Priority.LOW, file_transfer.cancellable);
+        yield output_stream.close_async(Priority.LOW, file_transfer.cancellable);
 
-                var computed_hashes = yield compute_file_hashes(file, checksum_types);
-                foreach (var checksum_type in hashes.keys) {
-                    if (hashes[checksum_type] != computed_hashes[checksum_type]) {
-                        warning("Hash of downloaded file does not equal advertised hash, discarding: %s. %s should be %s, was %s",
-                                file_transfer.file_name, checksum_type.to_string(), hashes[checksum_type], computed_hashes[checksum_type]);
-                        FileUtils.remove(file.get_path());
-                        file_transfer.state = FileTransfer.State.FAILED;
-                        return;
-                    }
-                }
-            }
+        if (limit_stream != null && limit_stream.remaining_bytes != 0) {
+            throw new IOError.FAILED("File download ended before the advertised size");
+        }
 
-            file_transfer.path = file.get_basename();
+        FileInfo file_info = partial_file.query_info(FileAttribute.STANDARD_SIZE, FileQueryInfoFlags.NONE);
+        int64 downloaded_size = file_info.get_size();
+        if (downloaded_size == 0 && file_transfer.size != 0) {
+            throw new IOError.FAILED("File download returned an empty body");
+        }
+        int64 expected_size = file_decryptor == null
+                ? file_meta.size
+                : file_decryptor.get_expected_file_size(file_transfer, file_meta.size);
+        if (expected_size >= 0 && downloaded_size != expected_size) {
+            throw new IOError.FAILED("Downloaded file size does not match the advertised size");
+        }
 
-            FileInfo file_info = file_transfer.get_file().query_info("*", FileQueryInfoFlags.NONE);
+        // Verify the hash of the downloaded file, if it is known
+        yield verify_file_hashes(partial_file, file_transfer);
+        partial_file.move(file, FileCopyFlags.OVERWRITE, file_transfer.cancellable, null);
+
+        try {
+            file_info = file.query_info("*", FileQueryInfoFlags.NONE);
             if (file_info.get_content_type() != "application/octet-stream" || file_transfer.content_type == null) {
                 // Only overwrite mime_type if it's better than what we had before.
                 file_transfer.content_type = new FileContentType.from_file_info(file_info);
             }
-
-            file_transfer.state = FileTransfer.State.COMPLETE;
-        } catch (IOError.CANCELLED e) {
-            print("cancelled\n");
         } catch (Error e) {
-            warning("Error downloading file: %s", e.message);
-            if (file_transfer.provider == 0 || file_transfer.provider == FileManager.SFS_PROVIDER_ID) {
-                file_transfer.state = FileTransfer.State.NOT_STARTED;
-            } else {
-                file_transfer.state = FileTransfer.State.FAILED;
+            warning("Error determining downloaded file type: %s", e.message);
+        }
+    }
+
+    private async void verify_file_hashes(File file, FileTransfer file_transfer) throws Error {
+        var supported_hashes = Xep.CryptographicHashes.get_supported_hashes(file_transfer.hashes);
+        if (supported_hashes.is_empty) return;
+
+        var checksum_types = new ArrayList<ChecksumType>();
+        var hashes = new HashMap<ChecksumType, string>();
+        foreach (var hash in supported_hashes) {
+            var checksum_type = Xep.CryptographicHashes.hash_string_to_type(hash.algo);
+            checksum_types.add(checksum_type);
+            hashes[checksum_type] = hash.val;
+        }
+
+        var computed_hashes = yield compute_file_hashes(file, checksum_types);
+        foreach (var checksum_type in hashes.keys) {
+            if (hashes[checksum_type] != computed_hashes[checksum_type]) {
+                throw new IOError.FAILED("Downloaded file hash does not match the advertised hash");
             }
         }
+    }
+
+    private void cancel_download(FileTransfer file_transfer) {
+        remove_partial_file(file_transfer);
+        file_transfer.path = null;
+        file_transfer.state = FileTransfer.State.NOT_STARTED;
+    }
+
+    private void fail_download(FileTransfer file_transfer) {
+        remove_partial_file(file_transfer);
+        file_transfer.state = FileTransfer.State.FAILED;
+    }
+
+    private void remove_partial_file(FileTransfer file_transfer) {
+        File? partial_file = file_transfer.get_partial_file();
+        if (partial_file != null) FileUtils.remove(partial_file.get_path());
     }
 
     public FileTransfer create_file_transfer_from_provider_incoming(FileProvider file_provider, string info, Jid from, DateTime time, DateTime local_time, Conversation conversation, FileReceiveData receive_data, FileMeta file_meta) {
@@ -382,6 +463,9 @@ public class FileManager : StreamInteractionModule, Object {
         FileTransfer file_transfer = create_file_transfer_from_provider_incoming(file_provider, info, from, time, local_time, conversation, receive_data, file_meta);
         stream_interactor.get_module(FileTransferStorage.IDENTITY).add_file(file_transfer);
 
+        conversation.last_active = file_transfer.time;
+        received_file(file_transfer, conversation);
+
         if (fm2.is_sender_trustworthy(file_transfer, conversation)) {
             try {
                 yield get_file_meta(file_provider, file_transfer, conversation, receive_data);
@@ -395,9 +479,6 @@ public class FileManager : StreamInteractionModule, Object {
                 });
             }
         }
-
-        conversation.last_active = file_transfer.time;
-        received_file(file_transfer, conversation);
     }
 
     public Message? get_message_for_file_transfer(FileTransfer file_transfer, Conversation conversation) {
@@ -482,6 +563,7 @@ public interface FileEncryptor : Object {
 
 public interface FileDecryptor : Object {
     public abstract Encryption get_encryption();
+    public abstract int64 get_expected_file_size(FileTransfer file_transfer, int64 download_size);
     public abstract FileReceiveData prepare_get_meta_info(Conversation conversation, FileTransfer file_transfer, FileReceiveData receive_data);
     public abstract FileMeta prepare_download_file(Conversation conversation, FileTransfer file_transfer, FileReceiveData receive_data, FileMeta file_meta);
     public abstract bool can_decrypt_file(Conversation conversation, FileTransfer file_transfer, FileReceiveData receive_data);

--- a/libdino/src/service/file_transfer_storage.vala
+++ b/libdino/src/service/file_transfer_storage.vala
@@ -18,6 +18,7 @@ namespace Dino {
         private WeakMap<int, FileTransferGroup> file_group_by_db_id = new WeakMap<int, FileTransferGroup>();
         private WeakMap<int, FileTransferGroup> file_group_by_message_id = new WeakMap<int, FileTransferGroup>();
         private WeakMap<string, FileTransfer> files_by_message_and_file_id = new WeakMap<string, FileTransfer>();
+        private HashSet<int> automatically_retried_files = new HashSet<int>();
 
         public static void start(StreamInteractor stream_interactor, Database db) {
             FileTransferStorage m = new FileTransferStorage(stream_interactor, db);
@@ -126,6 +127,41 @@ namespace Dino {
                 warning("Got file transfer with invalid Jid: %s", e.message);
             }
             return null;
+        }
+
+        public void recover_incomplete_file(FileTransfer file_transfer) {
+            if (file_transfer.direction != FileTransfer.DIRECTION_RECEIVED) return;
+
+            if (file_transfer.state != FileTransfer.State.IN_PROGRESS) {
+                File? partial_file = file_transfer.get_partial_file();
+                if (partial_file != null) FileUtils.remove(partial_file.get_path());
+            }
+
+            if (file_transfer.state == FileTransfer.State.COMPLETE) {
+                File? file = file_transfer.get_file();
+                bool valid = file != null && file.query_exists();
+                int64 expected_size = stream_interactor.get_module(FileManager.IDENTITY).get_expected_file_size(file_transfer);
+                if (valid && expected_size >= 0) {
+                    try {
+                        FileInfo file_info = file.query_info(FileAttribute.STANDARD_SIZE, FileQueryInfoFlags.NONE);
+                        valid = file_info.get_size() == expected_size;
+                    } catch (Error e) {
+                        valid = false;
+                    }
+                }
+                if (valid) return;
+
+                if (file != null) FileUtils.remove(file.get_path());
+                file_transfer.state = FileTransfer.State.NOT_STARTED;
+            }
+
+            if (file_transfer.state == FileTransfer.State.NOT_STARTED && file_transfer.path != null &&
+                    file_transfer.id != -1 && automatically_retried_files.add(file_transfer.id)) {
+                Idle.add_once(() => {
+                    if (file_transfer.state != FileTransfer.State.NOT_STARTED || file_transfer.path == null) return;
+                    stream_interactor.get_module(FileManager.IDENTITY).download_file.begin(file_transfer);
+                });
+            }
         }
 
         private FileTransferGroup? create_file_group_from_row(Row file_transfer_group_row, Conversation conversation) {

--- a/libdino/src/service/message_deletion.vala
+++ b/libdino/src/service/message_deletion.vala
@@ -66,9 +66,10 @@ namespace Dino {
             // If it's a file transfer, remove the file
             if (content_item.type_ == FileItem.TYPE) {
                 FileItem file_item = (FileItem) content_item;
-                if (file_item.file_transfer.path != null) {
-                    FileUtils.remove(file_item.file_transfer.path);
-                }
+                File? file = file_item.file_transfer.get_file();
+                File? partial_file = file_item.file_transfer.get_partial_file();
+                if (file != null) FileUtils.remove(file.get_path());
+                if (partial_file != null) FileUtils.remove(partial_file.get_path());
             }
 
             // Mark the (underlying) message as removed and clear the body

--- a/libdino/src/service/stateless_file_sharing.vala
+++ b/libdino/src/service/stateless_file_sharing.vala
@@ -160,11 +160,14 @@ public class Dino.StatelessFileSharing : StreamInteractionModule, Object {
             return;
         }
 
+        int source_count = file_transfer.sfs_sources.size;
         foreach (var source in sources) {
             file_transfer.add_sfs_source(source);
         }
 
-        if (fm2.is_sender_trustworthy(file_transfer, conversation) && file_transfer.state == FileTransfer.State.NOT_STARTED && file_transfer.size >= 0 && file_transfer.size < 5000000) {
+        if (file_transfer.sfs_sources.size > source_count && fm2.is_sender_trustworthy(file_transfer, conversation) &&
+                (file_transfer.state == FileTransfer.State.NOT_STARTED || file_transfer.state == FileTransfer.State.FAILED) &&
+                file_transfer.size >= 0 && file_transfer.size < 5000000) {
             fm.download_file(file_transfer);
         }
     }

--- a/main/src/ui/conversation_content_view/conversation_item_skeleton.vala
+++ b/main/src/ui/conversation_content_view/conversation_item_skeleton.vala
@@ -192,6 +192,11 @@ public class ConversationItemSkeleton : Plugins.ConversationItemWidgetInterface,
     }
 
     private void update_received_mark() {
+        received_image.remove_css_class("error");
+        time_label.remove_css_class("error");
+        received_image.tooltip_text = null;
+        time_label.tooltip_text = null;
+
         switch (content_meta_item.mark) {
             case Message.Marked.RECEIVED: 
                 received_image.icon_name = "dino-tick-symbolic";

--- a/main/src/ui/conversation_content_view/file_default_widget.vala
+++ b/main/src/ui/conversation_content_view/file_default_widget.vala
@@ -51,7 +51,7 @@ public class FileDefaultWidget : Box {
         mime_label.label = content_type != null ? content_type.get_description() : null;
     }
 
-    public void update_file_info(Xmpp.FileContentType? content_type, FileTransfer.State state, bool direction, int64 size, int64 transferred_bytes) {
+    public void update_file_info(Xmpp.FileContentType? content_type, FileTransfer.State state, bool direction, int64 size, int64 transferred_bytes, bool can_refetch) {
         this.state = state;
 
         spinner.stop(); // A hidden spinning spinner still uses CPU. Deactivate asap
@@ -68,6 +68,7 @@ public class FileDefaultWidget : Box {
                 Menu menu_model = new Menu();
                 menu_model.append(_("Open"), "file.open");
                 menu_model.append(_("Save as…"), "file.save_as");
+                if (can_refetch) menu_model.append(_("Refetch"), "file.refetch");
                 Gtk.PopoverMenu popover_menu = new Gtk.PopoverMenu.from_model(menu_model);
                 file_menu.popover = popover_menu;
                 popover_menu.closed.connect(on_pointer_left);
@@ -89,7 +90,7 @@ public class FileDefaultWidget : Box {
 
                 // Create a menu
                 Menu menu_model = new Menu();
-                menu_model.append(_("Cancel"), "file.cancel_download");
+                menu_model.append(_("Cancel"), "file.cancel");
                 Gtk.PopoverMenu popover_menu = new Gtk.PopoverMenu.from_model(menu_model);
                 file_menu.popover = popover_menu;
                 popover_menu.closed.connect(on_pointer_left);

--- a/main/src/ui/conversation_content_view/file_default_widget.vala
+++ b/main/src/ui/conversation_content_view/file_default_widget.vala
@@ -55,6 +55,7 @@ public class FileDefaultWidget : Box {
         this.state = file_transfer.state;
 
         spinner.stop(); // A hidden spinning spinner still uses CPU. Deactivate asap
+        mime_label.use_markup = false;
 
         content_type_image.icon_name = get_file_icon_name(file_transfer.content_type);
         string? mime_description = file_transfer.content_type != null ? file_transfer.content_type.get_description() : null;
@@ -97,7 +98,9 @@ public class FileDefaultWidget : Box {
 
                 // Create a menu
                 Menu menu_model = new Menu();
-                menu_model.append(_("Cancel"), "file.cancel_download");
+                MenuItem cancel_item = new MenuItem(_("Cancel"), "app.file_cancel_download");
+                cancel_item.set_action_and_target_value("app.file_cancel_download", new Variant.int32(file_transfer.id));
+                menu_model.append_item(cancel_item);
                 Gtk.PopoverMenu popover_menu = new Gtk.PopoverMenu.from_model(menu_model);
                 file_menu.popover = popover_menu;
                 popover_menu.closed.connect(on_pointer_left);
@@ -123,7 +126,7 @@ public class FileDefaultWidget : Box {
     private void on_pointer_entered_event() {
         this.set_cursor_from_name("pointer");
         content_type_image.opacity = 0.7;
-        if (state == FileTransfer.State.NOT_STARTED) {
+        if (state == FileTransfer.State.NOT_STARTED || state == FileTransfer.State.FAILED) {
             image_stack.set_visible_child_name("download_image");
         }
         if (state == FileTransfer.State.COMPLETE || state == FileTransfer.State.IN_PROGRESS) {
@@ -140,7 +143,7 @@ public class FileDefaultWidget : Box {
 
     private void on_pointer_left() {
         content_type_image.opacity = 0.5;
-        if (state == FileTransfer.State.NOT_STARTED) {
+        if (state == FileTransfer.State.NOT_STARTED || state == FileTransfer.State.FAILED) {
             image_stack.set_visible_child_name("content_type_image");
         }
         file_menu.opacity = 0;

--- a/main/src/ui/conversation_content_view/file_group_widget.vala
+++ b/main/src/ui/conversation_content_view/file_group_widget.vala
@@ -21,6 +21,9 @@ namespace Dino.Ui {
 
         public override Object? get_widget(Plugins.ConversationItemWidgetInterface outer, Plugins.WidgetType type) {
             var file_transfers = file_group_item.file_group.file_transfers;
+            foreach (FileTransfer file_transfer in file_transfers) {
+                stream_interactor.get_module(FileTransferStorage.IDENTITY).recover_incomplete_file(file_transfer);
+            }
 
             if (file_transfers.size > 1 && all_files_images(file_transfers)) {
                 return new ImageGroupWidget(file_transfers);

--- a/main/src/ui/conversation_content_view/file_image_widget.vala
+++ b/main/src/ui/conversation_content_view/file_image_widget.vala
@@ -20,7 +20,10 @@ public class FileImageWidget : Widget {
 
     private bool show_image_overlay_toolbar = false;
     private Gtk.Box image_overlay_toolbar = new Gtk.Box(Orientation.VERTICAL, 0) { halign=Align.END, valign=Align.START, margin_top=10, margin_start=10, margin_end=10, margin_bottom=10, vexpand=false, visible=false };
+    private MenuButton file_menu_button = new MenuButton() { icon_name = "dino-view-more" };
     private Label file_size_label = new Label(null) { halign=Align.START, valign=Align.END, margin_bottom=4, margin_start=4, visible=false };
+    private Widget? image_widget;
+    private string? displayed_path;
 
     private FileTransfer file_transfer;
 
@@ -37,14 +40,8 @@ public class FileImageWidget : Widget {
         this.add_css_class("file-image-widget");
 
         // Setup menu button overlay
-        MenuButton button = new MenuButton();
-        button.icon_name = "dino-view-more";
-        Menu menu_model = new Menu();
-        menu_model.append(_("Open"), "file.open");
-        menu_model.append(_("Save as…"), "file.save_as");
-        Gtk.PopoverMenu popover_menu = new Gtk.PopoverMenu.from_model(menu_model);
-        button.popover = popover_menu;
-        image_overlay_toolbar.append(button);
+        update_menu();
+        image_overlay_toolbar.append(file_menu_button);
         image_overlay_toolbar.add_css_class("card");
         image_overlay_toolbar.add_css_class("toolbar");
         image_overlay_toolbar.add_css_class("compact-card-toolbar");
@@ -71,7 +68,15 @@ public class FileImageWidget : Widget {
         this_motion_events.enter.connect((controller, x, y) => {
             (controller.widget as FileImageWidget).on_motion_event_enter();
         });
-        attach_on_motion_event_leave(this_motion_events, button);
+        attach_on_motion_event_leave(this_motion_events, file_menu_button);
+    }
+
+    private void update_menu() {
+        Menu menu_model = new Menu();
+        menu_model.append(_("Open"), "file.open");
+        menu_model.append(_("Save as…"), "file.save_as");
+        if (file_transfer != null && FileWidget.can_refetch(file_transfer)) menu_model.append(_("Refetch"), "file.refetch");
+        file_menu_button.popover = new Gtk.PopoverMenu.from_model(menu_model);
     }
 
     private static void attach_on_motion_event_leave(EventControllerMotion this_motion_events, MenuButton button) {
@@ -96,6 +101,7 @@ public class FileImageWidget : Widget {
         this.file_transfer.bind_property("transferred-bytes", transmission_progress, "transferred-size");
 
         file_transfer.notify["state"].connect(refresh_state);
+        file_transfer.notify["path"].connect(refresh_state);
         file_transfer.sources_changed.connect(refresh_state);
         refresh_state();
     }
@@ -106,8 +112,10 @@ public class FileImageWidget : Widget {
     }
 
     private void refresh_state() {
-        if ((state == EMPTY || state == PREVIEW) && file_transfer.path != null) {
-            load_from_file.begin(file_transfer.get_file(), file_transfer.file_name);
+        update_menu();
+
+        if (file_transfer.path != null && file_transfer.path != displayed_path) {
+            load_from_file.begin(file_transfer.get_file(), file_transfer.file_name, file_transfer.path);
             show_image_overlay_toolbar = true;
             this.set_cursor_from_name("zoom-in");
 
@@ -152,7 +160,7 @@ public class FileImageWidget : Widget {
         }
     }
 
-    public async void load_from_file(File file, string file_name) throws GLib.Error {
+    public async void load_from_file(File file, string file_name, string path) throws GLib.Error {
         FixedRatioPicture image = new FixedRatioPicture() { min_width=100, min_height=100, max_width=600, max_height=300 };
 
         FileInputStream file_stream = null;
@@ -169,6 +177,14 @@ public class FileImageWidget : Widget {
                 // Ignore
             }
         }
+
+        if (file_transfer.path != path) return;
+
+        if (image_widget != null) {
+            stack.remove(image_widget);
+        }
+        image_widget = image;
+        displayed_path = path;
 
         stack.add_child(image);
         stack.set_visible_child(image);

--- a/main/src/ui/conversation_content_view/file_image_widget.vala
+++ b/main/src/ui/conversation_content_view/file_image_widget.vala
@@ -78,7 +78,7 @@ public class FileImageWidget : Widget {
             Dino.Application.get_default().activate_action("file_start_download", new Variant.int32(file_transfer_id));
         });
         transmission_progress.cancel_transfer.connect(() => {
-            Dino.Application.get_default().activate_action("file_cancel_transfer", new Variant.int32(file_transfer_id));
+            Dino.Application.get_default().activate_action("file_cancel_download", new Variant.int32(file_transfer_id));
         });
     }
 
@@ -133,7 +133,7 @@ public class FileImageWidget : Widget {
     }
 
     private void refresh_state() {
-        if ((state == EMPTY || state == PREVIEW) && file_transfer.path != null) {
+        if ((state == EMPTY || state == PREVIEW) && file_transfer.state == COMPLETE && file_transfer.path != null) {
             load_from_file.begin(file_transfer.get_file(), file_transfer.file_name);
             show_image_overlay_toolbar = true;
             this.set_cursor_from_name("zoom-in");

--- a/main/src/ui/conversation_content_view/file_transmission_progress.vala
+++ b/main/src/ui/conversation_content_view/file_transmission_progress.vala
@@ -128,7 +128,6 @@ namespace Dino.Ui {
                 case DOWNLOAD_NOT_STARTED_FAILED_BEFORE:
                 case DOWNLOAD_NOT_STARTED:
                     start_download();
-                    this.activate_action("file.download", null);
                     break;
                 case DOWNLOADING:
                 case UPLOADING:

--- a/main/src/ui/conversation_content_view/file_widget.vala
+++ b/main/src/ui/conversation_content_view/file_widget.vala
@@ -61,12 +61,14 @@ public class FileWidget : SizeRequestBin {
     public signal void save_file_as();
     public signal void start_download();
     public signal void cancel_download();
+    public signal void refetch_file();
 
     class construct {
         install_action("file.open", null, (widget, action_name) => { ((FileWidget) widget).open_file(); });
         install_action("file.save_as", null, (widget, action_name) => { ((FileWidget) widget).save_file_as(); });
         install_action("file.download", null, (widget, action_name) => { ((FileWidget) widget).start_download(); });
         install_action("file.cancel", null, (widget, action_name) => { ((FileWidget) widget).cancel_download(); });
+        install_action("file.refetch", null, (widget, action_name) => { ((FileWidget) widget).refetch_file(); });
     }
 
     construct {
@@ -90,6 +92,15 @@ public class FileWidget : SizeRequestBin {
 
         this.notify["file-transfer-state"].connect(update_widget);
         this.notify["file-transfer-content-type"].connect(update_widget);
+    }
+
+    public static bool can_refetch(FileTransfer file_transfer) {
+        if (file_transfer.state != FileTransfer.State.COMPLETE) return false;
+
+        if (file_transfer.provider == FileManager.SFS_PROVIDER_ID) {
+            return !file_transfer.sfs_sources.is_empty;
+        }
+        return file_transfer.provider == FileManager.HTTP_PROVIDER_ID && file_transfer.info != null;
     }
 
     private async void update_widget() {
@@ -157,6 +168,7 @@ public class FileWidgetController : Object {
         widget.save_file_as.connect(save_file);
         widget.start_download.connect(start_download);
         widget.cancel_download.connect(cancel_download);
+        widget.refetch_file.connect(refetch_file);
     }
 
     private void open_file() {
@@ -197,6 +209,13 @@ public class FileWidgetController : Object {
     private void cancel_download() {
         file_transfer.cancellable.cancel();
     }
+
+    private void refetch_file() {
+        if (stream_interactor != null && FileWidget.can_refetch(file_transfer)) {
+            file_transfer.transferred_bytes = 0;
+            stream_interactor.get_module(FileManager.IDENTITY).download_file.begin(file_transfer);
+        }
+    }
 }
 
 public class FileDefaultWidgetController : Object {
@@ -234,7 +253,7 @@ public class FileDefaultWidgetController : Object {
 
     private void update_file_info() {
         state = file_transfer.state;
-        widget.update_file_info(file_transfer.content_type, file_transfer.state, file_transfer.direction, file_transfer.size, file_transfer.transferred_bytes);
+        widget.update_file_info(file_transfer.content_type, file_transfer.state, file_transfer.direction, file_transfer.size, file_transfer.transferred_bytes, FileWidget.can_refetch(file_transfer));
     }
 
     private void on_clicked() {

--- a/main/src/ui/conversation_content_view/file_widget.vala
+++ b/main/src/ui/conversation_content_view/file_widget.vala
@@ -22,6 +22,7 @@ public class FileMetaItem : ConversationSummary.ContentMetaItem {
     }
 
     public override Object? get_widget(Plugins.ConversationItemWidgetInterface outer, Plugins.WidgetType type) {
+        stream_interactor.get_module(FileTransferStorage.IDENTITY).recover_incomplete_file(file_transfer);
         FileWidget widget = new FileWidget(file_transfer);
         FileWidgetController widget_controller = new FileWidgetController(widget, file_transfer, stream_interactor);
         return widget;
@@ -182,10 +183,11 @@ public class FileDefaultWidgetController : Object {
                 Dino.Application.get_default().activate_action("file_open_externally", new GLib.Variant.int32(file_transfer.id));
                 break;
             case FileTransfer.State.NOT_STARTED:
+            case FileTransfer.State.FAILED:
                 Dino.Application.get_default().activate_action("file_start_download", new GLib.Variant.int32(file_transfer.id));
                 break;
             default:
-                // Clicking doesn't do anything in FAILED and IN_PROGRESS states
+                // Clicking doesn't do anything in IN_PROGRESS state
                 break;
         }
     }

--- a/plugins/http-files/src/file_provider.vala
+++ b/plugins/http-files/src/file_provider.vala
@@ -120,6 +120,10 @@ public class FileProvider : Dino.FileProvider, Object {
 #else
         InputStream stream = yield session.send_async(get_message, file_transfer.cancellable);
 #endif
+        if (get_message.status_code != 200) {
+            try { stream.close(); } catch (Error e) {}
+            throw new IOError.FAILED("HTTP status code %u".printf(get_message.status_code));
+        }
         if (file_meta.size != -1) {
             return new LimitInputStream(stream, file_meta.size);
         } else {

--- a/plugins/omemo/src/file_transfer/file_decryptor.vala
+++ b/plugins/omemo/src/file_transfer/file_decryptor.vala
@@ -11,10 +11,16 @@ public class OmemoHttpFileReceiveData : HttpFileReceiveData {
 
 public class OmemoFileDecryptor : FileDecryptor, Object {
 
+    private const int AUTH_TAG_SIZE = 16;
     private Regex url_regex = /^aesgcm:\/\/(.*)#(([A-Fa-f0-9]{2}){48}|([A-Fa-f0-9]{2}){44})$/;
 
     public Encryption get_encryption() {
         return Encryption.OMEMO;
+    }
+
+    public int64 get_expected_file_size(FileTransfer file_transfer, int64 download_size) {
+        if (file_transfer.provider != FileManager.HTTP_PROVIDER_ID) return file_transfer.size;
+        return download_size >= AUTH_TAG_SIZE ? download_size - AUTH_TAG_SIZE : -1;
     }
 
     public FileReceiveData prepare_get_meta_info(Conversation conversation, FileTransfer file_transfer, FileReceiveData receive_data) {
@@ -62,7 +68,7 @@ public class OmemoFileDecryptor : FileDecryptor, Object {
             SymmetricCipher cipher = new SymmetricCipher("AES-GCM");
             cipher.set_key(key);
             cipher.set_iv(iv);
-            return new ConverterInputStream(encrypted_stream, new SymmetricCipherDecrypter((owned) cipher, 16));
+            return new ConverterInputStream(encrypted_stream, new SymmetricCipherDecrypter((owned) cipher, AUTH_TAG_SIZE));
 
         } catch (Crypto.Error e) {
             throw new FileReceiveError.DECRYPTION_FAILED("OMEMO file decryption error: %s".printf(e.message));

--- a/plugins/openpgp/src/file_transfer/file_decryptor.vala
+++ b/plugins/openpgp/src/file_transfer/file_decryptor.vala
@@ -8,6 +8,10 @@ public class PgpFileDecryptor : FileDecryptor, Object {
         return Encryption.PGP;
     }
 
+    public int64 get_expected_file_size(FileTransfer file_transfer, int64 download_size) {
+        return -1;
+    }
+
     public FileReceiveData prepare_get_meta_info(Conversation conversation, FileTransfer file_transfer, FileReceiveData receive_data) {
         return receive_data;
     }


### PR DESCRIPTION
Completed HTTP and SFS file transfers may point at a cached file which was only partially fetched, but Dino still treats that cache path as complete. Add a Refetch action to the file, video, and photo menus; it reuses the existing download path, forcing a new GET and replacing the stored cache path when the transfer completes.

Reload image widgets when the file transfer path changes, so photos show the newly fetched cache entry rather than the previous texture. Correct the in progress file menu to call the existing cancel action.